### PR TITLE
FEAT: LinkedIn integration for blog post publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,10 @@
 # Environment files (secrets)
 *.env
+*.env.local
 !*.env.example
 backend/.env
 .env
+backend/.linkedin_token.json
 
 # Database
 db.sqlite3

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -66,6 +66,20 @@ WOMPI_INTEGRITY_SECRET=test_integrity_xxxxx
 WOMPI_API_URL=https://sandbox.wompi.co/v1
 
 # ===========================================
+# LINKEDIN (OAuth 2.0 — Blog post sharing)
+# ===========================================
+LINKEDIN_CLIENT_ID=replace
+LINKEDIN_CLIENT_SECRET=replace
+LINKEDIN_REDIRECT_URI=https://projectapp.co/auth/linkedin/callback
+# Generate with: python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+LINKEDIN_ENCRYPTION_KEY=replace
+
+# ===========================================
+# CACHE (Redis ��� db 1, Huey uses db 5)
+# ===========================================
+CACHE_REDIS_URL=redis://localhost:6379/1
+
+# ===========================================
 # MONITORING (Silk - conditional)
 # ===========================================
 ENABLE_SILK=false

--- a/backend/content/migrations/0071_add_linkedin_fields_to_blogpost.py
+++ b/backend/content/migrations/0071_add_linkedin_fields_to_blogpost.py
@@ -1,0 +1,43 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0070_add_email_sent_change_type'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='blogpost',
+            name='linkedin_summary_es',
+            field=models.TextField(
+                blank=True, default='',
+                help_text='Resumen para publicar en LinkedIn (español). Máximo ~1300 caracteres.',
+            ),
+        ),
+        migrations.AddField(
+            model_name='blogpost',
+            name='linkedin_summary_en',
+            field=models.TextField(
+                blank=True, default='',
+                help_text='Summary for LinkedIn post (English). Max ~1300 characters.',
+            ),
+        ),
+        migrations.AddField(
+            model_name='blogpost',
+            name='linkedin_post_id',
+            field=models.CharField(
+                blank=True, default='', max_length=255,
+                help_text='LinkedIn post URN after successful publication.',
+            ),
+        ),
+        migrations.AddField(
+            model_name='blogpost',
+            name='linkedin_published_at',
+            field=models.DateTimeField(
+                blank=True, null=True,
+                help_text='Timestamp of last successful LinkedIn publication.',
+            ),
+        ),
+    ]

--- a/backend/content/migrations/0072_linkedintoken.py
+++ b/backend/content/migrations/0072_linkedintoken.py
@@ -1,0 +1,31 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0071_add_linkedin_fields_to_blogpost'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='LinkedInToken',
+            fields=[
+                ('id', models.BigAutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('access_token_encrypted', models.TextField(blank=True, default='', help_text='Fernet-encrypted LinkedIn access token.')),
+                ('refresh_token_encrypted', models.TextField(blank=True, default='', help_text='Fernet-encrypted LinkedIn refresh token.')),
+                ('expires_at', models.DateTimeField(blank=True, help_text='When the access token expires.', null=True)),
+                ('refresh_token_expires_at', models.DateTimeField(blank=True, help_text='When the refresh token expires (typically 60 days).', null=True)),
+                ('member_sub', models.CharField(blank=True, default='', help_text='LinkedIn member "sub" claim (used to build urn:li:person:XXX).', max_length=100)),
+                ('profile_name', models.CharField(blank=True, default='', max_length=255)),
+                ('profile_picture', models.URLField(blank=True, default='', max_length=500)),
+                ('profile_email', models.EmailField(blank=True, default='', max_length=254)),
+                ('obtained_at', models.DateTimeField(blank=True, null=True)),
+                ('updated_at', models.DateTimeField(auto_now=True)),
+            ],
+            options={
+                'verbose_name': 'LinkedIn Token',
+                'verbose_name_plural': 'LinkedIn Tokens',
+            },
+        ),
+    ]

--- a/backend/content/models/__init__.py
+++ b/backend/content/models/__init__.py
@@ -34,3 +34,4 @@ from .document_payment_method import DocumentPaymentMethod
 from .company_settings import CompanySettings
 from .proposal_document import ProposalDocument
 from .contract_template import ContractTemplate
+from .linkedin_token import LinkedInToken

--- a/backend/content/models/blog_post.py
+++ b/backend/content/models/blog_post.py
@@ -131,6 +131,23 @@ class BlogPost(models.Model):
         help_text='Comma-separated SEO keywords in English.',
     )
 
+    linkedin_summary_es = models.TextField(
+        blank=True, default='',
+        help_text='Resumen para publicar en LinkedIn (español). Máximo ~1300 caracteres.',
+    )
+    linkedin_summary_en = models.TextField(
+        blank=True, default='',
+        help_text='Summary for LinkedIn post (English). Max ~1300 characters.',
+    )
+    linkedin_post_id = models.CharField(
+        max_length=255, blank=True, default='',
+        help_text='LinkedIn post URN after successful publication.',
+    )
+    linkedin_published_at = models.DateTimeField(
+        null=True, blank=True,
+        help_text='Timestamp of last successful LinkedIn publication.',
+    )
+
     is_published = models.BooleanField(default=False)
     published_at = models.DateTimeField(null=True, blank=True)
 

--- a/backend/content/models/linkedin_token.py
+++ b/backend/content/models/linkedin_token.py
@@ -1,0 +1,154 @@
+"""
+Singleton model for encrypted LinkedIn OAuth token storage.
+
+Uses Fernet symmetric encryption from the `cryptography` library.
+The encryption key is loaded from settings.LINKEDIN_ENCRYPTION_KEY.
+"""
+
+import logging
+
+from cryptography.fernet import Fernet, InvalidToken
+from django.conf import settings
+from django.db import models
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+
+def _get_fernet():
+    """Return a Fernet instance from the configured encryption key, or None."""
+    key = getattr(settings, 'LINKEDIN_ENCRYPTION_KEY', '')
+    if not key:
+        return None
+    try:
+        return Fernet(key.encode() if isinstance(key, str) else key)
+    except (ValueError, TypeError):
+        logger.error('Invalid LINKEDIN_ENCRYPTION_KEY — cannot encrypt/decrypt tokens.')
+        return None
+
+
+class LinkedInToken(models.Model):
+    """
+    Singleton model storing the LinkedIn OAuth access & refresh tokens.
+
+    Follows the CompanySettings singleton pattern: pk is always 1,
+    use ``LinkedInToken.load()`` to retrieve the instance.
+    """
+
+    access_token_encrypted = models.TextField(
+        blank=True, default='',
+        help_text='Fernet-encrypted LinkedIn access token.',
+    )
+    refresh_token_encrypted = models.TextField(
+        blank=True, default='',
+        help_text='Fernet-encrypted LinkedIn refresh token.',
+    )
+    expires_at = models.DateTimeField(
+        null=True, blank=True,
+        help_text='When the access token expires.',
+    )
+    refresh_token_expires_at = models.DateTimeField(
+        null=True, blank=True,
+        help_text='When the refresh token expires (typically 60 days).',
+    )
+
+    # Cached profile info (avoids extra API calls)
+    member_sub = models.CharField(
+        max_length=100, blank=True, default='',
+        help_text='LinkedIn member "sub" claim (used to build urn:li:person:XXX).',
+    )
+    profile_name = models.CharField(max_length=255, blank=True, default='')
+    profile_picture = models.URLField(max_length=500, blank=True, default='')
+    profile_email = models.EmailField(blank=True, default='')
+
+    obtained_at = models.DateTimeField(null=True, blank=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        verbose_name = 'LinkedIn Token'
+        verbose_name_plural = 'LinkedIn Tokens'
+
+    def __str__(self):
+        return f'LinkedInToken (connected={bool(self.access_token_encrypted)})'
+
+    def save(self, *args, **kwargs):
+        self.pk = 1
+        super().save(*args, **kwargs)
+
+    @classmethod
+    def load(cls):
+        """Return the singleton instance, creating it if needed."""
+        obj, _ = cls.objects.get_or_create(pk=1)
+        return obj
+
+    # ------------------------------------------------------------------
+    # Encryption helpers
+    # ------------------------------------------------------------------
+
+    def set_access_token(self, plaintext: str) -> None:
+        f = _get_fernet()
+        if f is None:
+            raise ValueError('LINKEDIN_ENCRYPTION_KEY is not configured.')
+        self.access_token_encrypted = f.encrypt(plaintext.encode()).decode()
+
+    def get_access_token(self) -> str | None:
+        if not self.access_token_encrypted:
+            return None
+        f = _get_fernet()
+        if f is None:
+            return None
+        try:
+            return f.decrypt(self.access_token_encrypted.encode()).decode()
+        except InvalidToken:
+            logger.error('Failed to decrypt access token — key may have changed.')
+            return None
+
+    def set_refresh_token(self, plaintext: str) -> None:
+        f = _get_fernet()
+        if f is None:
+            raise ValueError('LINKEDIN_ENCRYPTION_KEY is not configured.')
+        self.refresh_token_encrypted = f.encrypt(plaintext.encode()).decode()
+
+    def get_refresh_token(self) -> str | None:
+        if not self.refresh_token_encrypted:
+            return None
+        f = _get_fernet()
+        if f is None:
+            return None
+        try:
+            return f.decrypt(self.refresh_token_encrypted.encode()).decode()
+        except InvalidToken:
+            logger.error('Failed to decrypt refresh token — key may have changed.')
+            return None
+
+    # ------------------------------------------------------------------
+    # Expiry checks
+    # ------------------------------------------------------------------
+
+    @property
+    def is_expired(self) -> bool:
+        if not self.expires_at:
+            return True
+        return timezone.now() >= self.expires_at
+
+    @property
+    def is_refresh_expired(self) -> bool:
+        if not self.refresh_token_expires_at:
+            return True
+        return timezone.now() >= self.refresh_token_expires_at
+
+    # ------------------------------------------------------------------
+    # Clear
+    # ------------------------------------------------------------------
+
+    def clear(self) -> None:
+        """Remove all stored token data."""
+        self.access_token_encrypted = ''
+        self.refresh_token_encrypted = ''
+        self.expires_at = None
+        self.refresh_token_expires_at = None
+        self.member_sub = ''
+        self.profile_name = ''
+        self.profile_picture = ''
+        self.profile_email = ''
+        self.obtained_at = None

--- a/backend/content/serializers/blog.py
+++ b/backend/content/serializers/blog.py
@@ -157,6 +157,8 @@ class BlogPostAdminDetailSerializer(serializers.ModelSerializer):
             'meta_title_es', 'meta_title_en',
             'meta_description_es', 'meta_description_en',
             'meta_keywords_es', 'meta_keywords_en',
+            'linkedin_summary_es', 'linkedin_summary_en',
+            'linkedin_post_id', 'linkedin_published_at',
             'is_published', 'published_at',
             'created_at', 'updated_at',
         )
@@ -184,6 +186,7 @@ class BlogPostCreateUpdateSerializer(serializers.ModelSerializer):
             'meta_title_es', 'meta_title_en',
             'meta_description_es', 'meta_description_en',
             'meta_keywords_es', 'meta_keywords_en',
+            'linkedin_summary_es', 'linkedin_summary_en',
             'is_published', 'published_at',
         )
         extra_kwargs = {
@@ -202,6 +205,8 @@ class BlogPostCreateUpdateSerializer(serializers.ModelSerializer):
             'meta_description_en': {'required': False},
             'meta_keywords_es': {'required': False},
             'meta_keywords_en': {'required': False},
+            'linkedin_summary_es': {'required': False},
+            'linkedin_summary_en': {'required': False},
             'cover_image_credit': {'required': False},
             'cover_image_credit_url': {'required': False},
             'author': {'required': False},
@@ -393,6 +398,8 @@ class BlogPostFromJSONSerializer(serializers.Serializer):
     meta_keywords_en = serializers.CharField(max_length=500, required=False, default='', allow_blank=True)
     cover_image_credit = serializers.CharField(max_length=255, required=False, default='', allow_blank=True)
     cover_image_credit_url = serializers.CharField(required=False, default='', allow_blank=True)
+    linkedin_summary_es = serializers.CharField(required=False, default='', allow_blank=True)
+    linkedin_summary_en = serializers.CharField(required=False, default='', allow_blank=True)
 
     def validate_content_json_es(self, value):
         return _validate_content_json(value)

--- a/backend/content/services/linkedin_service.py
+++ b/backend/content/services/linkedin_service.py
@@ -1,0 +1,403 @@
+"""
+LinkedIn OAuth 2.0 + Post Publishing Service.
+
+Handles:
+- OAuth 2.0 authorization code flow (3-legged)
+- Encrypted token storage via LinkedInToken singleton model
+- Automatic token refresh when access token expires
+- Publishing blog post summaries with cover images to LinkedIn
+
+LinkedIn API docs:
+  - Auth: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow
+  - Posts: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
+"""
+
+import logging
+from datetime import timedelta
+from urllib.parse import urlencode
+
+import requests
+from django.conf import settings
+from django.utils import timezone
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+LINKEDIN_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization'
+LINKEDIN_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken'
+LINKEDIN_USERINFO_URL = 'https://api.linkedin.com/v2/userinfo'
+LINKEDIN_POSTS_URL = 'https://api.linkedin.com/rest/posts'
+
+LINKEDIN_SCOPES = 'openid profile email w_member_social'
+LINKEDIN_API_VERSION = '202401'
+
+# LinkedIn refresh tokens last 60 days
+_REFRESH_TOKEN_LIFETIME_DAYS = 60
+
+
+# ---------------------------------------------------------------------------
+# Token persistence (encrypted singleton model)
+# ---------------------------------------------------------------------------
+
+def _save_token(token_response: dict) -> None:
+    """
+    Persist token data from LinkedIn token endpoint to the encrypted model.
+
+    Expects keys: access_token, expires_in, and optionally refresh_token.
+    """
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    now = timezone.now()
+
+    token.set_access_token(token_response['access_token'])
+    token.expires_at = now + timedelta(seconds=token_response.get('expires_in', 5_184_000))
+    token.obtained_at = now
+
+    refresh = token_response.get('refresh_token')
+    if refresh:
+        token.set_refresh_token(refresh)
+        token.refresh_token_expires_at = now + timedelta(days=_REFRESH_TOKEN_LIFETIME_DAYS)
+
+    token.save()
+    logger.info('LinkedIn token saved (encrypted) — expires at %s.', token.expires_at)
+
+
+def _clear_token() -> None:
+    """Remove all stored token data."""
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    token.clear()
+    token.save()
+    logger.info('LinkedIn token cleared.')
+
+
+def _refresh_access_token() -> str | None:
+    """
+    Attempt to refresh the access token using the stored refresh token.
+
+    Returns the new access token on success, None on failure.
+    """
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    refresh_tok = token.get_refresh_token()
+
+    if not refresh_tok or token.is_refresh_expired:
+        logger.warning('No valid refresh token available — clearing token.')
+        _clear_token()
+        return None
+
+    resp = requests.post(
+        LINKEDIN_TOKEN_URL,
+        data={
+            'grant_type': 'refresh_token',
+            'refresh_token': refresh_tok,
+            'client_id': settings.LINKEDIN_CLIENT_ID,
+            'client_secret': settings.LINKEDIN_CLIENT_SECRET,
+        },
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        timeout=15,
+    )
+
+    if resp.status_code != 200:
+        logger.error('LinkedIn token refresh failed: %s %s', resp.status_code, resp.text)
+        _clear_token()
+        return None
+
+    data = resp.json()
+    now = timezone.now()
+
+    token.set_access_token(data['access_token'])
+    token.expires_at = now + timedelta(seconds=data.get('expires_in', 5_184_000))
+    token.obtained_at = now
+    # LinkedIn does not rotate refresh tokens on refresh
+    token.save()
+
+    logger.info('LinkedIn access token refreshed — new expiry %s.', token.expires_at)
+    return data['access_token']
+
+
+# ---------------------------------------------------------------------------
+# OAuth 2.0 flow
+# ---------------------------------------------------------------------------
+
+def get_authorization_url(state: str = '') -> str:
+    """Build the LinkedIn OAuth 2.0 authorization URL."""
+    params = {
+        'response_type': 'code',
+        'client_id': settings.LINKEDIN_CLIENT_ID,
+        'redirect_uri': settings.LINKEDIN_REDIRECT_URI,
+        'scope': LINKEDIN_SCOPES,
+    }
+    if state:
+        params['state'] = state
+    return f'{LINKEDIN_AUTH_URL}?{urlencode(params)}'
+
+
+def exchange_code_for_token(code: str) -> dict:
+    """
+    Exchange authorization code for access token.
+
+    Saves the encrypted token to the database.
+    Returns the raw token response dict.
+    Raises ValueError on failure.
+    """
+    resp = requests.post(
+        LINKEDIN_TOKEN_URL,
+        data={
+            'grant_type': 'authorization_code',
+            'code': code,
+            'redirect_uri': settings.LINKEDIN_REDIRECT_URI,
+            'client_id': settings.LINKEDIN_CLIENT_ID,
+            'client_secret': settings.LINKEDIN_CLIENT_SECRET,
+        },
+        headers={'Content-Type': 'application/x-www-form-urlencoded'},
+        timeout=15,
+    )
+    if resp.status_code != 200:
+        logger.error('LinkedIn token exchange failed: %s %s', resp.status_code, resp.text)
+        raise ValueError(f'LinkedIn token exchange failed: {resp.text}')
+
+    token_data = resp.json()
+    _save_token(token_data)
+
+    # Fetch and cache the user profile
+    _cache_profile_info()
+
+    logger.info('LinkedIn access token obtained and encrypted.')
+    return token_data
+
+
+def get_access_token() -> str | None:
+    """
+    Return the access token, refreshing automatically if expired.
+
+    Returns None if not connected or refresh also failed.
+    """
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    access = token.get_access_token()
+
+    if not access:
+        return None
+
+    if not token.is_expired:
+        return access
+
+    # Token expired — try refresh
+    logger.info('LinkedIn access token expired, attempting refresh.')
+    return _refresh_access_token()
+
+
+# ---------------------------------------------------------------------------
+# LinkedIn profile
+# ---------------------------------------------------------------------------
+
+def _fetch_profile_from_api(access_token: str) -> dict | None:
+    """Call LinkedIn userinfo API and return the response dict."""
+    resp = requests.get(
+        LINKEDIN_USERINFO_URL,
+        headers={'Authorization': f'Bearer {access_token}'},
+        timeout=10,
+    )
+    if resp.status_code != 200:
+        logger.error('LinkedIn profile fetch failed: %s', resp.text)
+        return None
+    return resp.json()
+
+
+def _cache_profile_info() -> None:
+    """Fetch profile from API and cache it on the token model."""
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    access = token.get_access_token()
+    if not access:
+        return
+
+    profile = _fetch_profile_from_api(access)
+    if not profile:
+        return
+
+    token.member_sub = profile.get('sub', '')
+    token.profile_name = profile.get('name', '')
+    token.profile_picture = profile.get('picture', '')
+    token.profile_email = profile.get('email', '')
+    token.save(update_fields=[
+        'member_sub', 'profile_name', 'profile_picture', 'profile_email',
+    ])
+
+
+def get_member_urn() -> str | None:
+    """Return the LinkedIn member URN (urn:li:person:XXX)."""
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+
+    # Use cached sub if available
+    if token.member_sub:
+        return f'urn:li:person:{token.member_sub}'
+
+    # Fallback: fetch from API
+    access = get_access_token()
+    if not access:
+        return None
+
+    profile = _fetch_profile_from_api(access)
+    if not profile or not profile.get('sub'):
+        return None
+
+    # Cache for next time
+    token.member_sub = profile['sub']
+    token.profile_name = profile.get('name', '')
+    token.save(update_fields=['member_sub', 'profile_name'])
+
+    return f'urn:li:person:{profile["sub"]}'
+
+
+# ---------------------------------------------------------------------------
+# Publishing
+# ---------------------------------------------------------------------------
+
+def publish_blog_to_linkedin(
+    summary: str,
+    blog_url: str,
+    title: str,
+    cover_image_url: str = '',
+) -> dict:
+    """
+    Publish a blog post summary to LinkedIn as a link share.
+
+    Args:
+        summary: The text content for the LinkedIn post.
+        blog_url: Full URL to the blog post on projectapp.co.
+        title: Title of the blog post (used in the article preview).
+        cover_image_url: URL of the cover image for the article thumbnail.
+
+    Returns:
+        dict with 'success', 'post_id' (LinkedIn URN), and 'message'.
+
+    Raises:
+        ValueError: If not connected to LinkedIn or missing required data.
+    """
+    access_token = get_access_token()
+    if not access_token:
+        raise ValueError('LinkedIn not connected. Please authorize first.')
+
+    member_urn = get_member_urn()
+    if not member_urn:
+        raise ValueError('Could not retrieve LinkedIn member URN.')
+
+    if not summary:
+        raise ValueError('Summary text is required for LinkedIn post.')
+
+    # Build the post payload (LinkedIn Posts API v2)
+    post_data = {
+        'author': member_urn,
+        'commentary': summary,
+        'visibility': 'PUBLIC',
+        'distribution': {
+            'feedDistribution': 'MAIN_FEED',
+            'targetEntities': [],
+            'thirdPartyDistributionChannels': [],
+        },
+        'content': {
+            'article': {
+                'source': blog_url,
+                'title': title,
+            },
+        },
+        'lifecycleState': 'PUBLISHED',
+        'isReshareDisabledByAuthor': False,
+    }
+
+    # Add thumbnail if cover image is available
+    if cover_image_url:
+        post_data['content']['article']['thumbnail'] = cover_image_url
+
+    headers = {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': 'application/json',
+        'X-Restli-Protocol-Version': '2.0.0',
+        'LinkedIn-Version': LINKEDIN_API_VERSION,
+    }
+
+    resp = requests.post(
+        LINKEDIN_POSTS_URL,
+        json=post_data,
+        headers=headers,
+        timeout=15,
+    )
+
+    if resp.status_code in (200, 201):
+        post_id = resp.headers.get('x-restli-id', '')
+        logger.info('LinkedIn post published: %s', post_id)
+        return {
+            'success': True,
+            'post_id': post_id,
+            'message': 'Post published to LinkedIn successfully.',
+        }
+
+    logger.error('LinkedIn publish failed: %s %s', resp.status_code, resp.text)
+    return {
+        'success': False,
+        'post_id': '',
+        'message': f'LinkedIn API error ({resp.status_code}): {resp.text}',
+    }
+
+
+# ---------------------------------------------------------------------------
+# Connection status
+# ---------------------------------------------------------------------------
+
+def get_connection_status() -> dict:
+    """
+    Check if LinkedIn is connected and return status info.
+
+    Uses cached profile info from the model to avoid unnecessary API calls.
+    Falls back to API call if profile isn't cached.
+    """
+    from content.models import LinkedInToken
+
+    token = LinkedInToken.load()
+    access = token.get_access_token()
+
+    if not access:
+        return {'connected': False}
+
+    # Use cached profile info if available
+    if token.profile_name:
+        return {
+            'connected': True,
+            'profile_name': token.profile_name,
+            'profile_picture': token.profile_picture,
+            'email': token.profile_email,
+        }
+
+    # Fallback: fetch from API and cache
+    profile = _fetch_profile_from_api(access)
+    if not profile:
+        _clear_token()
+        return {'connected': False, 'reason': 'Token expired or invalid.'}
+
+    # Cache profile info
+    token.member_sub = profile.get('sub', '')
+    token.profile_name = profile.get('name', '')
+    token.profile_picture = profile.get('picture', '')
+    token.profile_email = profile.get('email', '')
+    token.save(update_fields=[
+        'member_sub', 'profile_name', 'profile_picture', 'profile_email',
+    ])
+
+    return {
+        'connected': True,
+        'profile_name': token.profile_name,
+        'profile_picture': token.profile_picture,
+        'email': token.profile_email,
+    }

--- a/backend/content/tests/services/test_linkedin_service.py
+++ b/backend/content/tests/services/test_linkedin_service.py
@@ -122,9 +122,10 @@ class TestExchangeCodeForToken:
         mock_resp.text = 'invalid_grant'
         mock_post.return_value = mock_resp
 
-        with pytest.raises(ValueError, match='token exchange failed'):
+        with pytest.raises(ValueError, match='token exchange failed') as exc_info:
             linkedin_service.exchange_code_for_token('bad-code')
 
+        assert 'token exchange failed' in str(exc_info.value)
         mock_post.assert_called_once()
 
     @override_settings(**LINKEDIN_SETTINGS)
@@ -272,11 +273,12 @@ class TestPublishBlogToLinkedin:
 
     @patch('content.services.linkedin_service.get_access_token', return_value=None)
     def test_raises_when_not_connected(self, mock_token):
-        with pytest.raises(ValueError, match='not connected'):
+        with pytest.raises(ValueError, match='not connected') as exc_info:
             linkedin_service.publish_blog_to_linkedin(
                 summary='Test', blog_url='https://x.co', title='T',
             )
 
+        assert 'not connected' in str(exc_info.value)
         mock_token.assert_called_once()
 
     @patch('content.services.linkedin_service.requests.post')

--- a/backend/content/tests/services/test_linkedin_service.py
+++ b/backend/content/tests/services/test_linkedin_service.py
@@ -3,12 +3,11 @@
 Covers: token exchange, encrypted storage, auto-refresh, publish,
 connection status, and encryption round-trip.
 """
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_tz
 from unittest.mock import MagicMock, patch
 
 import pytest
 from django.test import override_settings
-from django.utils import timezone
 from freezegun import freeze_time
 
 from content.models import LinkedInToken
@@ -16,16 +15,13 @@ from content.services import linkedin_service
 
 pytestmark = pytest.mark.django_db
 
-FROZEN_NOW = timezone.datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
-
-# A valid Fernet key for tests (generated once, safe to embed in tests)
-TEST_FERNET_KEY = 'dGVzdGtleTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNA=='
+FROZEN_NOW = datetime(2026, 4, 4, 12, 0, 0, tzinfo=dt_tz.utc)
 
 LINKEDIN_SETTINGS = {
     'LINKEDIN_CLIENT_ID': 'test-client-id',
     'LINKEDIN_CLIENT_SECRET': 'test-client-secret',
     'LINKEDIN_REDIRECT_URI': 'https://example.com/callback',
-    'LINKEDIN_ENCRYPTION_KEY': '',  # will be overridden per test
+    'LINKEDIN_ENCRYPTION_KEY': '',
 }
 
 
@@ -58,7 +54,7 @@ def token_with_refresh(fernet_key):
         token = LinkedInToken.load()
         token.set_access_token('expired-access-token')
         token.set_refresh_token('valid-refresh-token')
-        token.expires_at = FROZEN_NOW - timedelta(hours=1)  # expired
+        token.expires_at = FROZEN_NOW - timedelta(hours=1)
         token.refresh_token_expires_at = FROZEN_NOW + timedelta(days=30)
         token.obtained_at = FROZEN_NOW - timedelta(days=30)
         token.member_sub = 'abc123'
@@ -90,6 +86,8 @@ class TestExchangeCodeForToken:
             result = linkedin_service.exchange_code_for_token('auth-code-123')
 
             assert result['access_token'] == 'new-access-token'
+            mock_post.assert_called_once()
+            mock_cache.assert_called_once()
             token = LinkedInToken.load()
             assert token.get_access_token() == 'new-access-token'
             assert token.get_refresh_token() == 'new-refresh-token'
@@ -97,7 +95,8 @@ class TestExchangeCodeForToken:
 
     @override_settings(**LINKEDIN_SETTINGS)
     @patch('content.services.linkedin_service.requests.post')
-    def test_computes_expires_at_from_response(self, mock_post, fernet_key):
+    @patch('content.services.linkedin_service._cache_profile_info')
+    def test_computes_expires_at_from_response(self, mock_cache, mock_post, fernet_key):
         with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
             mock_resp = MagicMock()
             mock_resp.status_code = 200
@@ -107,12 +106,11 @@ class TestExchangeCodeForToken:
             }
             mock_post.return_value = mock_resp
 
-            with patch('content.services.linkedin_service._cache_profile_info'):
-                linkedin_service.exchange_code_for_token('code')
+            linkedin_service.exchange_code_for_token('code')
 
+            mock_post.assert_called_once()
             token = LinkedInToken.load()
             assert token.expires_at is not None
-            # expires_at should be ~1 hour from now
             delta = token.expires_at - token.obtained_at
             assert 3590 < delta.total_seconds() < 3610
 
@@ -126,6 +124,8 @@ class TestExchangeCodeForToken:
 
         with pytest.raises(ValueError, match='token exchange failed'):
             linkedin_service.exchange_code_for_token('bad-code')
+
+        mock_post.assert_called_once()
 
     @override_settings(**LINKEDIN_SETTINGS)
     @patch('content.services.linkedin_service.requests.post')
@@ -142,6 +142,7 @@ class TestExchangeCodeForToken:
 
             linkedin_service.exchange_code_for_token('code')
 
+            mock_post.assert_called_once()
             token = LinkedInToken.load()
             assert token.get_access_token() == 'access-only'
             assert token.get_refresh_token() is None
@@ -180,6 +181,7 @@ class TestGetAccessToken:
             result = linkedin_service.get_access_token()
             assert result == 'refreshed-access-token'
 
+            mock_post.assert_called_once()
             token = LinkedInToken.load()
             assert token.get_access_token() == 'refreshed-access-token'
 
@@ -221,6 +223,7 @@ class TestRefreshAccessToken:
 
             result = linkedin_service._refresh_access_token()
             assert result == 'new-from-refresh'
+            mock_post.assert_called_once()
 
     @freeze_time(FROZEN_NOW)
     @override_settings(**LINKEDIN_SETTINGS)
@@ -235,6 +238,7 @@ class TestRefreshAccessToken:
             result = linkedin_service._refresh_access_token()
             assert result is None
 
+            mock_post.assert_called_once()
             token = LinkedInToken.load()
             assert token.get_access_token() is None
 
@@ -264,6 +268,7 @@ class TestPublishBlogToLinkedin:
 
         assert result['success'] is True
         assert result['post_id'] == 'urn:li:share:123456'
+        mock_post.assert_called_once()
 
     @patch('content.services.linkedin_service.get_access_token', return_value=None)
     def test_raises_when_not_connected(self, mock_token):
@@ -271,6 +276,8 @@ class TestPublishBlogToLinkedin:
             linkedin_service.publish_blog_to_linkedin(
                 summary='Test', blog_url='https://x.co', title='T',
             )
+
+        mock_token.assert_called_once()
 
     @patch('content.services.linkedin_service.requests.post')
     @patch('content.services.linkedin_service.get_member_urn', return_value='urn:li:person:abc')
@@ -286,6 +293,7 @@ class TestPublishBlogToLinkedin:
             summary='Test', blog_url='https://x.co', title='T',
         )
         assert result['success'] is False
+        mock_post.assert_called_once()
 
 
 # ---------------------------------------------------------------------------
@@ -313,13 +321,13 @@ class TestGetConnectionStatus:
             token = LinkedInToken.load()
             token.set_access_token('some-token')
             token.expires_at = FROZEN_NOW + timedelta(days=30)
-            # profile_name is empty → triggers API call
             token.profile_name = ''
             token.save()
 
             result = linkedin_service.get_connection_status()
             assert result['connected'] is False
 
+            mock_fetch.assert_called_once()
             token.refresh_from_db()
             assert token.get_access_token() is None
 

--- a/backend/content/tests/services/test_linkedin_service.py
+++ b/backend/content/tests/services/test_linkedin_service.py
@@ -1,0 +1,348 @@
+"""Tests for LinkedIn OAuth service.
+
+Covers: token exchange, encrypted storage, auto-refresh, publish,
+connection status, and encryption round-trip.
+"""
+from datetime import timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+from django.test import override_settings
+from django.utils import timezone
+from freezegun import freeze_time
+
+from content.models import LinkedInToken
+from content.services import linkedin_service
+
+pytestmark = pytest.mark.django_db
+
+FROZEN_NOW = timezone.datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+# A valid Fernet key for tests (generated once, safe to embed in tests)
+TEST_FERNET_KEY = 'dGVzdGtleTEyMzQ1Njc4OTAxMjM0NTY3ODkwMTIzNA=='
+
+LINKEDIN_SETTINGS = {
+    'LINKEDIN_CLIENT_ID': 'test-client-id',
+    'LINKEDIN_CLIENT_SECRET': 'test-client-secret',
+    'LINKEDIN_REDIRECT_URI': 'https://example.com/callback',
+    'LINKEDIN_ENCRYPTION_KEY': '',  # will be overridden per test
+}
+
+
+@pytest.fixture
+def fernet_key():
+    """Generate a valid Fernet key for tests."""
+    from cryptography.fernet import Fernet
+    return Fernet.generate_key().decode()
+
+
+@pytest.fixture
+def token_with_access(fernet_key):
+    """A LinkedInToken with a valid access token."""
+    with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+        token = LinkedInToken.load()
+        token.set_access_token('test-access-token-123')
+        token.expires_at = FROZEN_NOW + timedelta(days=30)
+        token.obtained_at = FROZEN_NOW
+        token.member_sub = 'abc123'
+        token.profile_name = 'Test User'
+        token.profile_email = 'test@example.com'
+        token.save()
+        return token
+
+
+@pytest.fixture
+def token_with_refresh(fernet_key):
+    """A LinkedInToken with both access and refresh tokens (access expired)."""
+    with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+        token = LinkedInToken.load()
+        token.set_access_token('expired-access-token')
+        token.set_refresh_token('valid-refresh-token')
+        token.expires_at = FROZEN_NOW - timedelta(hours=1)  # expired
+        token.refresh_token_expires_at = FROZEN_NOW + timedelta(days=30)
+        token.obtained_at = FROZEN_NOW - timedelta(days=30)
+        token.member_sub = 'abc123'
+        token.profile_name = 'Test User'
+        token.save()
+        return token
+
+
+# ---------------------------------------------------------------------------
+# TestExchangeCodeForToken
+# ---------------------------------------------------------------------------
+
+class TestExchangeCodeForToken:
+
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    @patch('content.services.linkedin_service._cache_profile_info')
+    def test_saves_encrypted_token_on_success(self, mock_cache, mock_post, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                'access_token': 'new-access-token',
+                'expires_in': 5_184_000,
+                'refresh_token': 'new-refresh-token',
+            }
+            mock_post.return_value = mock_resp
+
+            result = linkedin_service.exchange_code_for_token('auth-code-123')
+
+            assert result['access_token'] == 'new-access-token'
+            token = LinkedInToken.load()
+            assert token.get_access_token() == 'new-access-token'
+            assert token.get_refresh_token() == 'new-refresh-token'
+            assert token.expires_at is not None
+
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    def test_computes_expires_at_from_response(self, mock_post, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                'access_token': 'tok',
+                'expires_in': 3600,
+            }
+            mock_post.return_value = mock_resp
+
+            with patch('content.services.linkedin_service._cache_profile_info'):
+                linkedin_service.exchange_code_for_token('code')
+
+            token = LinkedInToken.load()
+            assert token.expires_at is not None
+            # expires_at should be ~1 hour from now
+            delta = token.expires_at - token.obtained_at
+            assert 3590 < delta.total_seconds() < 3610
+
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    def test_raises_value_error_on_api_failure(self, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 400
+        mock_resp.text = 'invalid_grant'
+        mock_post.return_value = mock_resp
+
+        with pytest.raises(ValueError, match='token exchange failed'):
+            linkedin_service.exchange_code_for_token('bad-code')
+
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    @patch('content.services.linkedin_service._cache_profile_info')
+    def test_handles_missing_refresh_token(self, mock_cache, mock_post, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                'access_token': 'access-only',
+                'expires_in': 5_184_000,
+            }
+            mock_post.return_value = mock_resp
+
+            linkedin_service.exchange_code_for_token('code')
+
+            token = LinkedInToken.load()
+            assert token.get_access_token() == 'access-only'
+            assert token.get_refresh_token() is None
+
+
+# ---------------------------------------------------------------------------
+# TestGetAccessToken
+# ---------------------------------------------------------------------------
+
+class TestGetAccessToken:
+
+    @freeze_time(FROZEN_NOW)
+    def test_returns_token_when_valid(self, fernet_key, token_with_access):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            result = linkedin_service.get_access_token()
+            assert result == 'test-access-token-123'
+
+    def test_returns_none_when_no_token(self, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            result = linkedin_service.get_access_token()
+            assert result is None
+
+    @freeze_time(FROZEN_NOW)
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    def test_refreshes_expired_token(self, mock_post, fernet_key, token_with_refresh):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                'access_token': 'refreshed-access-token',
+                'expires_in': 5_184_000,
+            }
+            mock_post.return_value = mock_resp
+
+            result = linkedin_service.get_access_token()
+            assert result == 'refreshed-access-token'
+
+            token = LinkedInToken.load()
+            assert token.get_access_token() == 'refreshed-access-token'
+
+    @freeze_time(FROZEN_NOW)
+    def test_clears_token_when_refresh_also_expired(self, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            token = LinkedInToken.load()
+            token.set_access_token('expired')
+            token.set_refresh_token('also-expired')
+            token.expires_at = FROZEN_NOW - timedelta(hours=1)
+            token.refresh_token_expires_at = FROZEN_NOW - timedelta(days=1)
+            token.save()
+
+            result = linkedin_service.get_access_token()
+            assert result is None
+
+            token.refresh_from_db()
+            assert token.get_access_token() is None
+
+
+# ---------------------------------------------------------------------------
+# TestRefreshAccessToken
+# ---------------------------------------------------------------------------
+
+class TestRefreshAccessToken:
+
+    @freeze_time(FROZEN_NOW)
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    def test_successful_refresh_updates_token(self, mock_post, fernet_key, token_with_refresh):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 200
+            mock_resp.json.return_value = {
+                'access_token': 'new-from-refresh',
+                'expires_in': 5_184_000,
+            }
+            mock_post.return_value = mock_resp
+
+            result = linkedin_service._refresh_access_token()
+            assert result == 'new-from-refresh'
+
+    @freeze_time(FROZEN_NOW)
+    @override_settings(**LINKEDIN_SETTINGS)
+    @patch('content.services.linkedin_service.requests.post')
+    def test_failed_refresh_clears_token(self, mock_post, fernet_key, token_with_refresh):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            mock_resp = MagicMock()
+            mock_resp.status_code = 401
+            mock_resp.text = 'invalid_token'
+            mock_post.return_value = mock_resp
+
+            result = linkedin_service._refresh_access_token()
+            assert result is None
+
+            token = LinkedInToken.load()
+            assert token.get_access_token() is None
+
+
+# ---------------------------------------------------------------------------
+# TestPublishBlogToLinkedin
+# ---------------------------------------------------------------------------
+
+class TestPublishBlogToLinkedin:
+
+    @freeze_time(FROZEN_NOW)
+    @patch('content.services.linkedin_service.requests.post')
+    @patch('content.services.linkedin_service.get_member_urn', return_value='urn:li:person:abc')
+    @patch('content.services.linkedin_service.get_access_token', return_value='valid-token')
+    def test_successful_publish_returns_post_id(self, mock_token, mock_urn, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 201
+        mock_resp.headers = {'x-restli-id': 'urn:li:share:123456'}
+        mock_post.return_value = mock_resp
+
+        result = linkedin_service.publish_blog_to_linkedin(
+            summary='Test summary',
+            blog_url='https://projectapp.co/blog/test',
+            title='Test Post',
+            cover_image_url='https://example.com/img.jpg',
+        )
+
+        assert result['success'] is True
+        assert result['post_id'] == 'urn:li:share:123456'
+
+    @patch('content.services.linkedin_service.get_access_token', return_value=None)
+    def test_raises_when_not_connected(self, mock_token):
+        with pytest.raises(ValueError, match='not connected'):
+            linkedin_service.publish_blog_to_linkedin(
+                summary='Test', blog_url='https://x.co', title='T',
+            )
+
+    @patch('content.services.linkedin_service.requests.post')
+    @patch('content.services.linkedin_service.get_member_urn', return_value='urn:li:person:abc')
+    @patch('content.services.linkedin_service.get_access_token', return_value='valid-token')
+    def test_returns_failure_on_api_error(self, mock_token, mock_urn, mock_post):
+        mock_resp = MagicMock()
+        mock_resp.status_code = 403
+        mock_resp.text = 'Forbidden'
+        mock_resp.headers = {}
+        mock_post.return_value = mock_resp
+
+        result = linkedin_service.publish_blog_to_linkedin(
+            summary='Test', blog_url='https://x.co', title='T',
+        )
+        assert result['success'] is False
+
+
+# ---------------------------------------------------------------------------
+# TestGetConnectionStatus
+# ---------------------------------------------------------------------------
+
+class TestGetConnectionStatus:
+
+    @freeze_time(FROZEN_NOW)
+    def test_returns_connected_with_cached_profile(self, fernet_key, token_with_access):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            result = linkedin_service.get_connection_status()
+            assert result['connected'] is True
+            assert result['profile_name'] == 'Test User'
+
+    def test_returns_disconnected_when_no_token(self, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            result = linkedin_service.get_connection_status()
+            assert result['connected'] is False
+
+    @freeze_time(FROZEN_NOW)
+    @patch('content.services.linkedin_service._fetch_profile_from_api', return_value=None)
+    def test_clears_token_on_invalid_profile(self, mock_fetch, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            token = LinkedInToken.load()
+            token.set_access_token('some-token')
+            token.expires_at = FROZEN_NOW + timedelta(days=30)
+            # profile_name is empty → triggers API call
+            token.profile_name = ''
+            token.save()
+
+            result = linkedin_service.get_connection_status()
+            assert result['connected'] is False
+
+            token.refresh_from_db()
+            assert token.get_access_token() is None
+
+
+# ---------------------------------------------------------------------------
+# TestEncryptionHelpers
+# ---------------------------------------------------------------------------
+
+class TestEncryptionHelpers:
+
+    def test_round_trip_encryption(self, fernet_key):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=fernet_key):
+            token = LinkedInToken.load()
+            token.set_access_token('super-secret-token')
+            token.save()
+
+            token.refresh_from_db()
+            assert token.get_access_token() == 'super-secret-token'
+
+    def test_returns_none_with_empty_encryption_key(self):
+        with override_settings(LINKEDIN_ENCRYPTION_KEY=''):
+            token = LinkedInToken.load()
+            token.access_token_encrypted = 'some-encrypted-data'
+            token.save()
+
+            assert token.get_access_token() is None

--- a/backend/content/tests/views/test_linkedin_views.py
+++ b/backend/content/tests/views/test_linkedin_views.py
@@ -3,7 +3,7 @@
 Covers: OAuth auth URL, callback with state validation, connection status,
 and rate-limited publish endpoint.
 """
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone as dt_tz
 from unittest.mock import patch
 
 import pytest
@@ -16,7 +16,7 @@ from content.models import BlogPost
 
 pytestmark = pytest.mark.django_db
 
-FROZEN_NOW = timezone.datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
+FROZEN_NOW = datetime(2026, 4, 4, 12, 0, 0, tzinfo=dt_tz.utc)
 
 
 @pytest.fixture

--- a/backend/content/tests/views/test_linkedin_views.py
+++ b/backend/content/tests/views/test_linkedin_views.py
@@ -1,0 +1,199 @@
+"""Tests for LinkedIn integration views.
+
+Covers: OAuth auth URL, callback with state validation, connection status,
+and rate-limited publish endpoint.
+"""
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.core.cache import cache
+from django.urls import reverse
+from django.utils import timezone
+from freezegun import freeze_time
+
+from content.models import BlogPost
+
+pytestmark = pytest.mark.django_db
+
+FROZEN_NOW = timezone.datetime(2026, 4, 4, 12, 0, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def blog_post_with_summary(db):
+    """A published blog post with LinkedIn summary fields populated."""
+    return BlogPost.objects.create(
+        title_es='Post de prueba',
+        title_en='Test post',
+        slug='test-linkedin-post',
+        excerpt_es='Extracto.',
+        excerpt_en='Excerpt.',
+        linkedin_summary_es='Resumen para LinkedIn en español.',
+        linkedin_summary_en='LinkedIn summary in English.',
+        is_published=True,
+        published_at=timezone.now(),
+    )
+
+
+@pytest.fixture
+def blog_post_no_summary(db):
+    """A published blog post without LinkedIn summary."""
+    return BlogPost.objects.create(
+        title_es='Post sin resumen',
+        title_en='Post without summary',
+        slug='no-summary-post',
+        excerpt_es='Extracto.',
+        excerpt_en='Excerpt.',
+        is_published=True,
+        published_at=timezone.now(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# TestLinkedinAuthUrl
+# ---------------------------------------------------------------------------
+
+class TestLinkedinAuthUrl:
+
+    def test_returns_authorization_url_for_admin(self, admin_client):
+        response = admin_client.get(reverse('linkedin-auth-url'))
+        assert response.status_code == 200
+        assert 'authorization_url' in response.data
+        assert 'state' in response.data
+        assert 'linkedin.com/oauth' in response.data['authorization_url']
+
+    def test_stores_state_in_cache(self, admin_client):
+        response = admin_client.get(reverse('linkedin-auth-url'))
+        state = response.data['state']
+        assert cache.get(f'linkedin_oauth_state:{state}') is True
+
+    def test_rejects_unauthenticated_user(self, api_client):
+        response = api_client.get(reverse('linkedin-auth-url'))
+        assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# TestLinkedinCallback
+# ---------------------------------------------------------------------------
+
+class TestLinkedinCallback:
+
+    @patch('content.views.linkedin.get_connection_status', return_value={'connected': True})
+    @patch('content.views.linkedin.exchange_code_for_token', return_value={'access_token': 'tok'})
+    def test_successful_callback_with_valid_state(self, mock_exchange, mock_status, admin_client):
+        # Pre-set state in cache
+        cache.set('linkedin_oauth_state:valid-state-123', True, timeout=600)
+
+        response = admin_client.post(
+            reverse('linkedin-callback'),
+            {'code': 'auth-code-abc', 'state': 'valid-state-123'},
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.data['success'] is True
+        # State should be consumed
+        assert cache.get('linkedin_oauth_state:valid-state-123') is None
+
+    def test_rejects_missing_state(self, admin_client):
+        response = admin_client.post(
+            reverse('linkedin-callback'),
+            {'code': 'auth-code'},
+            format='json',
+        )
+        assert response.status_code == 400
+        assert 'state' in response.data['error'].lower()
+
+    def test_rejects_invalid_state(self, admin_client):
+        response = admin_client.post(
+            reverse('linkedin-callback'),
+            {'code': 'auth-code', 'state': 'invalid-state-xyz'},
+            format='json',
+        )
+        assert response.status_code == 400
+        assert 'expired' in response.data['error'].lower() or 'invalid' in response.data['error'].lower()
+
+    @patch('content.views.linkedin.exchange_code_for_token', side_effect=ValueError('exchange failed'))
+    def test_returns_400_on_exchange_failure(self, mock_exchange, admin_client):
+        cache.set('linkedin_oauth_state:fail-state', True, timeout=600)
+        response = admin_client.post(
+            reverse('linkedin-callback'),
+            {'code': 'bad-code', 'state': 'fail-state'},
+            format='json',
+        )
+        assert response.status_code == 400
+        assert 'exchange failed' in response.data['error']
+
+
+# ---------------------------------------------------------------------------
+# TestLinkedinStatus
+# ---------------------------------------------------------------------------
+
+class TestLinkedinStatus:
+
+    @patch('content.views.linkedin.get_connection_status', return_value={'connected': True, 'profile_name': 'Admin'})
+    def test_returns_status_for_admin(self, mock_status, admin_client):
+        response = admin_client.get(reverse('linkedin-status'))
+        assert response.status_code == 200
+        assert response.data['connected'] is True
+
+    def test_rejects_unauthenticated(self, api_client):
+        response = api_client.get(reverse('linkedin-status'))
+        assert response.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# TestPublishToLinkedin
+# ---------------------------------------------------------------------------
+
+class TestPublishToLinkedin:
+
+    @patch('content.views.linkedin.publish_blog_to_linkedin', return_value={
+        'success': True, 'post_id': 'urn:li:share:999', 'message': 'OK',
+    })
+    def test_publishes_successfully(self, mock_publish, admin_client, blog_post_with_summary):
+        url = reverse('publish-to-linkedin', kwargs={'post_id': blog_post_with_summary.id})
+        response = admin_client.post(url, {'lang': 'es'}, format='json')
+        assert response.status_code == 200
+        assert response.data['success'] is True
+
+        blog_post_with_summary.refresh_from_db()
+        assert blog_post_with_summary.linkedin_post_id == 'urn:li:share:999'
+        assert blog_post_with_summary.linkedin_published_at is not None
+
+    def test_returns_404_for_nonexistent_post(self, admin_client):
+        url = reverse('publish-to-linkedin', kwargs={'post_id': 99999})
+        response = admin_client.post(url, {'lang': 'es'}, format='json')
+        assert response.status_code == 404
+
+    def test_returns_400_for_empty_summary(self, admin_client, blog_post_no_summary):
+        url = reverse('publish-to-linkedin', kwargs={'post_id': blog_post_no_summary.id})
+        response = admin_client.post(url, {'lang': 'es'}, format='json')
+        assert response.status_code == 400
+        assert 'empty' in response.data['error'].lower()
+
+    @freeze_time(FROZEN_NOW)
+    @patch('content.views.linkedin.publish_blog_to_linkedin')
+    def test_rate_limits_duplicate_publish(self, mock_publish, admin_client, blog_post_with_summary):
+        # Simulate a recent publish (5 minutes ago)
+        blog_post_with_summary.linkedin_published_at = FROZEN_NOW - timedelta(minutes=5)
+        blog_post_with_summary.save()
+
+        url = reverse('publish-to-linkedin', kwargs={'post_id': blog_post_with_summary.id})
+        response = admin_client.post(url, {'lang': 'es'}, format='json')
+        assert response.status_code == 429
+        assert 'recently' in response.data['error'].lower() or 'wait' in response.data['error'].lower()
+        mock_publish.assert_not_called()
+
+    @freeze_time(FROZEN_NOW)
+    @patch('content.views.linkedin.publish_blog_to_linkedin', return_value={
+        'success': True, 'post_id': 'urn:li:share:new', 'message': 'OK',
+    })
+    def test_allows_publish_after_cooldown(self, mock_publish, admin_client, blog_post_with_summary):
+        # Simulate a publish 15 minutes ago (past cooldown)
+        blog_post_with_summary.linkedin_published_at = FROZEN_NOW - timedelta(minutes=15)
+        blog_post_with_summary.save()
+
+        url = reverse('publish-to-linkedin', kwargs={'post_id': blog_post_with_summary.id})
+        response = admin_client.post(url, {'lang': 'es'}, format='json')
+        assert response.status_code == 200
+        assert response.data['success'] is True

--- a/backend/content/urls.py
+++ b/backend/content/urls.py
@@ -50,6 +50,10 @@ from content.views.blog import (
     retrieve_admin_blog_post, update_blog_post, delete_blog_post,
     duplicate_blog_post, upload_blog_cover_image, blog_calendar,
 )
+from content.views.linkedin import (
+    linkedin_auth_url, linkedin_callback, linkedin_status,
+    publish_to_linkedin,
+)
 from content.views.document import (
     list_documents, create_document, create_document_from_markdown,
     upload_document_markdown, retrieve_document, update_document,
@@ -155,6 +159,12 @@ urlpatterns = [
     path('blog/admin/<int:post_id>/duplicate/', duplicate_blog_post, name='duplicate-blog-post'),
     path('blog/admin/<int:post_id>/upload-cover/', upload_blog_cover_image, name='upload-blog-cover-image'),
     path('blog/admin/calendar/', blog_calendar, name='blog-calendar'),
+    path('blog/admin/<int:post_id>/publish-linkedin/', publish_to_linkedin, name='publish-to-linkedin'),
+
+    # LinkedIn OAuth
+    path('linkedin/auth-url/', linkedin_auth_url, name='linkedin-auth-url'),
+    path('linkedin/callback/', linkedin_callback, name='linkedin-callback'),
+    path('linkedin/status/', linkedin_status, name='linkedin-status'),
 
     # Blog — public
     path('blog/', list_blog_posts, name='list-blog-posts'),

--- a/backend/content/views/blog.py
+++ b/backend/content/views/blog.py
@@ -311,6 +311,8 @@ def create_blog_post_from_json(request):
         meta_keywords_en=data.get('meta_keywords_en', ''),
         cover_image_credit=data.get('cover_image_credit', ''),
         cover_image_credit_url=data.get('cover_image_credit_url', ''),
+        linkedin_summary_es=data.get('linkedin_summary_es', ''),
+        linkedin_summary_en=data.get('linkedin_summary_en', ''),
     )
 
     detail = BlogPostAdminDetailSerializer(post)
@@ -348,6 +350,8 @@ def get_blog_json_template(request):
         'meta_description_en': '',
         'meta_keywords_es': '',
         'meta_keywords_en': '',
+        'linkedin_summary_es': 'Resumen para LinkedIn en español (máx. ~1300 caracteres).',
+        'linkedin_summary_en': 'LinkedIn summary in English (max ~1300 chars).',
         '_available_categories': AVAILABLE_CATEGORIES,
     }
     return Response(template, status=status.HTTP_200_OK)

--- a/backend/content/views/linkedin.py
+++ b/backend/content/views/linkedin.py
@@ -1,0 +1,186 @@
+"""
+LinkedIn integration views.
+
+Handles OAuth callback (with CSRF state validation), connection status,
+and rate-limited blog-to-LinkedIn publishing.
+"""
+
+import logging
+import math
+import secrets
+from datetime import timedelta
+
+from django.conf import settings
+from django.core.cache import cache
+from django.utils import timezone as tz
+from rest_framework import status
+from rest_framework.decorators import api_view, permission_classes
+from rest_framework.permissions import IsAdminUser
+from rest_framework.response import Response
+
+from content.models import BlogPost
+from content.services.linkedin_service import (
+    exchange_code_for_token,
+    get_authorization_url,
+    get_connection_status,
+    publish_blog_to_linkedin,
+)
+
+logger = logging.getLogger(__name__)
+
+BLOG_PUBLIC_BASE = 'https://projectapp.co/blog'
+
+# OAuth state cache prefix and TTL
+_STATE_PREFIX = 'linkedin_oauth_state:'
+_STATE_TTL = 600  # 10 minutes
+
+# Rate limit: minimum interval between LinkedIn publishes per post
+_PUBLISH_COOLDOWN = timedelta(minutes=10)
+
+
+@api_view(['GET'])
+@permission_classes([IsAdminUser])
+def linkedin_auth_url(request):
+    """
+    Return the LinkedIn OAuth authorization URL with a CSRF state token.
+
+    The state is stored in Redis cache for 10 minutes. The frontend must
+    pass it back on callback for validation.
+    """
+    state = secrets.token_urlsafe(32)
+    cache.set(f'{_STATE_PREFIX}{state}', True, timeout=_STATE_TTL)
+    url = get_authorization_url(state=state)
+    return Response({'authorization_url': url, 'state': state})
+
+
+@api_view(['POST'])
+@permission_classes([IsAdminUser])
+def linkedin_callback(request):
+    """
+    Exchange the LinkedIn authorization code for an access token.
+
+    Expects JSON body: { "code": "<auth_code>", "state": "<csrf_state>" }
+    Validates the state parameter against the cache before proceeding.
+    """
+    # --- Validate CSRF state ---
+    state = request.data.get('state')
+    if not state:
+        return Response(
+            {'error': 'Missing OAuth state parameter.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    cache_key = f'{_STATE_PREFIX}{state}'
+    if not cache.get(cache_key):
+        return Response(
+            {'error': 'Invalid or expired OAuth state. Please try again.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    cache.delete(cache_key)
+
+    # --- Check for errors from LinkedIn ---
+    error = request.data.get('error')
+    if error:
+        return Response(
+            {'error': f'LinkedIn authorization error: {error}'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # --- Exchange code ---
+    code = request.data.get('code')
+    if not code:
+        return Response(
+            {'error': 'Authorization code is required.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    try:
+        exchange_code_for_token(code)
+        connection = get_connection_status()
+        return Response({
+            'success': True,
+            'message': 'LinkedIn connected successfully.',
+            'connection': connection,
+        })
+    except ValueError as exc:
+        logger.error('LinkedIn callback failed: %s', exc)
+        return Response(
+            {'error': str(exc)},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+
+@api_view(['GET'])
+@permission_classes([IsAdminUser])
+def linkedin_status(request):
+    """Check LinkedIn connection status."""
+    connection = get_connection_status()
+    return Response(connection)
+
+
+@api_view(['POST'])
+@permission_classes([IsAdminUser])
+def publish_to_linkedin(request, post_id):
+    """
+    Publish a blog post summary to LinkedIn.
+
+    Rate-limited to one publish per post every 10 minutes to prevent
+    accidental duplicate posts.
+    """
+    post = BlogPost.objects.filter(pk=post_id).first()
+    if not post:
+        return Response(
+            {'error': 'Blog post not found.'},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    # --- Rate limit check ---
+    if post.linkedin_published_at:
+        threshold = tz.now() - _PUBLISH_COOLDOWN
+        if post.linkedin_published_at >= threshold:
+            remaining_seconds = (post.linkedin_published_at - threshold).total_seconds()
+            remaining_minutes = math.ceil(remaining_seconds / 60)
+            return Response(
+                {'error': f'This post was published to LinkedIn recently. Wait {remaining_minutes} min.'},
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+    lang = request.data.get('lang', 'es')
+    summary = post.linkedin_summary_es if lang == 'es' else post.linkedin_summary_en
+    title = post.title_es if lang == 'es' else post.title_en
+
+    if not summary:
+        return Response(
+            {'error': f'LinkedIn summary ({lang}) is empty. Please add a summary first.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    # Build blog URL
+    blog_url = f'{BLOG_PUBLIC_BASE}/{post.slug}'
+
+    # Get cover image URL
+    cover_image_url = ''
+    if post.cover_image_url:
+        cover_image_url = post.cover_image_url
+    elif post.cover_image:
+        cover_image_url = f'https://projectapp.co{post.cover_image.url}'
+
+    try:
+        result = publish_blog_to_linkedin(
+            summary=summary,
+            blog_url=blog_url,
+            title=title,
+            cover_image_url=cover_image_url,
+        )
+    except ValueError as exc:
+        return Response(
+            {'error': str(exc)},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+
+    if result['success']:
+        post.linkedin_post_id = result['post_id']
+        post.linkedin_published_at = tz.now()
+        post.save(update_fields=['linkedin_post_id', 'linkedin_published_at'])
+
+    return Response(result, status=status.HTTP_200_OK if result['success'] else status.HTTP_502_BAD_GATEWAY)

--- a/backend/projectapp/settings.py
+++ b/backend/projectapp/settings.py
@@ -227,6 +227,32 @@ WOMPI_API_URL = config('WOMPI_API_URL', default='https://sandbox.wompi.co/v1')
 RECAPTCHA_SECRET_KEY = config('RECAPTCHA_SECRET_KEY', default='')
 
 # ==============================================================================
+# LINKEDIN — OAuth 2.0 (blog post sharing)
+# ==============================================================================
+
+LINKEDIN_CLIENT_ID = config('LINKEDIN_CLIENT_ID', default='')
+LINKEDIN_CLIENT_SECRET = config('LINKEDIN_CLIENT_SECRET', default='')
+LINKEDIN_REDIRECT_URI = config(
+    'LINKEDIN_REDIRECT_URI',
+    default='https://projectapp.co/auth/linkedin/callback',
+)
+LINKEDIN_ENCRYPTION_KEY = config('LINKEDIN_ENCRYPTION_KEY', default='')
+
+# ==============================================================================
+# CACHE — Redis (db 1; Huey uses db 5)
+# ==============================================================================
+
+_CACHE_REDIS_URL = config('CACHE_REDIS_URL', default='')
+CACHES = {
+    'default': {
+        'BACKEND': 'django.core.cache.backends.redis.RedisCache',
+        'LOCATION': _CACHE_REDIS_URL,
+    } if _CACHE_REDIS_URL else {
+        'BACKEND': 'django.core.cache.backends.locmem.LocMemCache',
+    },
+}
+
+# ==============================================================================
 # HUEY — task queue
 # ==============================================================================
 

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -12,6 +12,7 @@ python-dateutil
 python-decouple>=3.8,<3.9
 redis>=4.0.0
 requests==2.31.0
+cryptography>=42.0,<44.0
 six==1.16.0
 sqlparse==0.5.0
 tzdata==2024.1

--- a/frontend/layouts/blank.vue
+++ b/frontend/layouts/blank.vue
@@ -1,0 +1,5 @@
+<template>
+  <div>
+    <slot />
+  </div>
+</template>

--- a/frontend/pages/auth/linkedin/callback.vue
+++ b/frontend/pages/auth/linkedin/callback.vue
@@ -1,0 +1,67 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-gray-50">
+    <div class="bg-white rounded-xl shadow-sm border border-gray-200 p-8 max-w-md w-full text-center">
+      <div v-if="isLoading" class="space-y-4">
+        <div class="w-8 h-8 border-2 border-[#0A66C2]/30 border-t-[#0A66C2] rounded-full animate-spin mx-auto" />
+        <p class="text-sm text-gray-600">Conectando con LinkedIn...</p>
+      </div>
+      <div v-else-if="success" class="space-y-4">
+        <div class="w-12 h-12 bg-emerald-50 rounded-full flex items-center justify-center mx-auto">
+          <svg class="w-6 h-6 text-emerald-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" /></svg>
+        </div>
+        <p class="text-sm text-gray-900 font-medium">LinkedIn conectado correctamente</p>
+        <p class="text-xs text-gray-500">Puedes cerrar esta ventana.</p>
+      </div>
+      <div v-else class="space-y-4">
+        <div class="w-12 h-12 bg-red-50 rounded-full flex items-center justify-center mx-auto">
+          <svg class="w-6 h-6 text-red-500" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M6 18L18 6M6 6l12 12" /></svg>
+        </div>
+        <p class="text-sm text-red-600">{{ errorMessage }}</p>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { ref, onMounted } from 'vue';
+import { useBlogStore } from '~/stores/blog';
+
+definePageMeta({ layout: 'blank' });
+
+const blogStore = useBlogStore();
+const isLoading = ref(true);
+const success = ref(false);
+const errorMessage = ref('');
+
+onMounted(async () => {
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const error = params.get('error');
+
+  if (error) {
+    isLoading.value = false;
+    errorMessage.value = `LinkedIn: ${params.get('error_description') || error}`;
+    return;
+  }
+
+  if (!code) {
+    isLoading.value = false;
+    errorMessage.value = 'No se recibió código de autorización.';
+    return;
+  }
+
+  const state = params.get('state') || '';
+  const result = await blogStore.linkedinCallback(code, state);
+  isLoading.value = false;
+
+  if (result.success) {
+    success.value = true;
+    // Notify opener window
+    if (window.opener) {
+      window.opener.postMessage({ type: 'linkedin-connected', data: result.data?.connection }, '*');
+    }
+  } else {
+    errorMessage.value = result.error || 'Error al conectar con LinkedIn.';
+  }
+});
+</script>

--- a/frontend/pages/panel/blog/[id]/edit.vue
+++ b/frontend/pages/panel/blog/[id]/edit.vue
@@ -153,6 +153,60 @@
           </div>
         </fieldset>
 
+        <!-- LinkedIn Summary -->
+        <fieldset class="border border-gray-200 rounded-xl p-5 space-y-4">
+          <legend class="text-sm font-medium text-gray-700 px-2">LinkedIn</legend>
+          <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">Resumen LinkedIn (ES)</label>
+              <textarea v-model="form.linkedin_summary_es" rows="4" maxlength="1300" class="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm leading-relaxed focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all resize-y" placeholder="Resumen para publicar en LinkedIn (max ~1300 caracteres)" />
+              <p class="text-xs text-gray-400 mt-1">{{ form.linkedin_summary_es.length }} / 1300</p>
+            </div>
+            <div>
+              <label class="block text-sm font-medium text-gray-700 mb-1">LinkedIn Summary (EN)</label>
+              <textarea v-model="form.linkedin_summary_en" rows="4" maxlength="1300" class="w-full px-4 py-3 rounded-xl border border-gray-200 text-sm leading-relaxed focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500 transition-all resize-y" placeholder="Summary for LinkedIn post (max ~1300 chars)" />
+              <p class="text-xs text-gray-400 mt-1">{{ form.linkedin_summary_en.length }} / 1300</p>
+            </div>
+          </div>
+
+          <!-- LinkedIn publish action -->
+          <div class="border-t border-gray-100 pt-4 mt-2">
+            <div v-if="!linkedinStatus.connected" class="flex items-center gap-3">
+              <span class="text-sm text-gray-500">LinkedIn no conectado.</span>
+              <button type="button" class="px-4 py-2 bg-[#0A66C2] text-white text-sm rounded-lg hover:bg-[#004182] transition-colors inline-flex items-center gap-2" @click="connectLinkedIn">
+                <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                Conectar LinkedIn
+              </button>
+            </div>
+            <div v-else class="space-y-3">
+              <div class="flex items-center gap-2 text-sm text-gray-600">
+                <span class="w-2 h-2 rounded-full bg-emerald-500" />
+                Conectado como <strong>{{ linkedinStatus.profile_name }}</strong>
+              </div>
+              <div class="flex items-center gap-3">
+                <select v-model="linkedinLang" class="px-3 py-2 rounded-lg border border-gray-200 text-sm focus:ring-2 focus:ring-emerald-500/20 focus:border-emerald-500">
+                  <option value="es">Publicar en Español</option>
+                  <option value="en">Publish in English</option>
+                </select>
+                <button
+                  type="button"
+                  :disabled="isPublishingLinkedIn || !(linkedinLang === 'es' ? form.linkedin_summary_es : form.linkedin_summary_en)"
+                  class="px-4 py-2 bg-[#0A66C2] text-white text-sm rounded-lg hover:bg-[#004182] transition-colors disabled:opacity-50 disabled:cursor-not-allowed inline-flex items-center gap-2"
+                  @click="publishToLinkedIn"
+                >
+                  <svg class="w-4 h-4" viewBox="0 0 24 24" fill="currentColor"><path d="M20.447 20.452h-3.554v-5.569c0-1.328-.027-3.037-1.852-3.037-1.853 0-2.136 1.445-2.136 2.939v5.667H9.351V9h3.414v1.561h.046c.477-.9 1.637-1.85 3.37-1.85 3.601 0 4.267 2.37 4.267 5.455v6.286zM5.337 7.433a2.062 2.062 0 01-2.063-2.065 2.064 2.064 0 112.063 2.065zm1.782 13.019H3.555V9h3.564v11.452zM22.225 0H1.771C.792 0 0 .774 0 1.729v20.542C0 23.227.792 24 1.771 24h20.451C23.2 24 24 23.227 24 22.271V1.729C24 .774 23.2 0 22.222 0h.003z"/></svg>
+                  {{ isPublishingLinkedIn ? 'Publicando...' : 'Publicar en LinkedIn' }}
+                </button>
+              </div>
+              <p v-if="post?.linkedin_published_at" class="text-xs text-gray-400">
+                Última publicación: {{ new Date(post.linkedin_published_at).toLocaleString() }}
+              </p>
+              <p v-if="linkedinMsg" class="text-sm text-emerald-600">{{ linkedinMsg }}</p>
+              <p v-if="linkedinError" class="text-sm text-red-500">{{ linkedinError }}</p>
+            </div>
+          </div>
+        </fieldset>
+
         <!-- Cover image -->
         <fieldset class="border border-gray-200 rounded-xl p-5 space-y-4">
           <legend class="text-sm font-medium text-gray-700 px-2">Imagen de portada</legend>
@@ -395,21 +449,48 @@ const form = reactive({
   meta_keywords_en: '',
   cover_image_credit: '',
   cover_image_credit_url: '',
+  linkedin_summary_es: '',
+  linkedin_summary_en: '',
 });
+
+// LinkedIn state
+const linkedinStatus = ref({ connected: false });
+const linkedinLang = ref('es');
+const linkedinMsg = ref('');
+const linkedinError = ref('');
+const isPublishingLinkedIn = ref(false);
 
 onMounted(async () => {
   windowWidth.value = window.innerWidth;
   window.addEventListener('resize', handleResize);
+  window.addEventListener('message', handleLinkedInMessage);
   blogStore.fetchCategories();
 
-  const result = await blogStore.fetchAdminPost(route.params.id);
+  const [result, liStatus] = await Promise.all([
+    blogStore.fetchAdminPost(route.params.id),
+    blogStore.fetchLinkedInStatus(),
+  ]);
   if (result.success && result.data) {
     populateForm(result.data);
+  }
+  if (liStatus.success) {
+    linkedinStatus.value = liStatus.data;
   }
   loaded.value = true;
 });
 
-onUnmounted(() => { window.removeEventListener('resize', handleResize); });
+function handleLinkedInMessage(event) {
+  if (event.data?.type === 'linkedin-connected') {
+    linkedinStatus.value = event.data.data || { connected: true };
+    linkedinMsg.value = 'LinkedIn conectado correctamente.';
+    setTimeout(() => { linkedinMsg.value = ''; }, 5000);
+  }
+}
+
+onUnmounted(() => {
+  window.removeEventListener('resize', handleResize);
+  window.removeEventListener('message', handleLinkedInMessage);
+});
 
 function jsonToStr(val) {
   if (!val || (typeof val === 'object' && Object.keys(val).length === 0)) return '';
@@ -450,6 +531,8 @@ function populateForm(data) {
   form.meta_keywords_en = data.meta_keywords_en || '';
   form.cover_image_credit = data.cover_image_credit || '';
   form.cover_image_credit_url = data.cover_image_credit_url || '';
+  form.linkedin_summary_es = data.linkedin_summary_es || '';
+  form.linkedin_summary_en = data.linkedin_summary_en || '';
 
   if (data.is_published) {
     publishMode.value = 'now';
@@ -501,6 +584,29 @@ function removeSource(idx) {
   form.sources.splice(idx, 1);
 }
 
+async function connectLinkedIn() {
+  const result = await blogStore.fetchLinkedInAuthUrl();
+  if (result.success && result.data?.authorization_url) {
+    window.open(result.data.authorization_url, '_blank', 'width=600,height=700');
+  }
+}
+
+async function publishToLinkedIn() {
+  linkedinMsg.value = '';
+  linkedinError.value = '';
+  isPublishingLinkedIn.value = true;
+
+  const result = await blogStore.publishToLinkedIn(route.params.id, linkedinLang.value);
+  isPublishingLinkedIn.value = false;
+
+  if (result.success) {
+    linkedinMsg.value = result.data?.message || 'Publicado en LinkedIn correctamente.';
+    setTimeout(() => { linkedinMsg.value = ''; }, 5000);
+  } else {
+    linkedinError.value = result.error || 'Error al publicar en LinkedIn.';
+  }
+}
+
 async function handleSubmit() {
   errorMsg.value = '';
   successMsg.value = '';
@@ -528,6 +634,8 @@ async function handleSubmit() {
     meta_keywords_en: form.meta_keywords_en,
     cover_image_credit: form.cover_image_credit,
     cover_image_credit_url: form.cover_image_credit_url,
+    linkedin_summary_es: form.linkedin_summary_es,
+    linkedin_summary_en: form.linkedin_summary_en,
   };
 
   if (publishMode.value === 'now') {

--- a/frontend/stores/blog.js
+++ b/frontend/stores/blog.js
@@ -356,5 +356,69 @@ export const useBlogStore = defineStore('blog', {
         return { success: false };
       }
     },
+
+    // -----------------------------------------------------------------
+    // LinkedIn integration
+    // -----------------------------------------------------------------
+
+    /**
+     * fetchLinkedInStatus: Check LinkedIn connection status.
+     */
+    async fetchLinkedInStatus() {
+      try {
+        const response = await get_request('linkedin/status/');
+        return { success: true, data: response.data };
+      } catch (error) {
+        console.error('Error fetching LinkedIn status:', error);
+        return { success: false };
+      }
+    },
+
+    /**
+     * fetchLinkedInAuthUrl: Get the LinkedIn OAuth authorization URL.
+     */
+    async fetchLinkedInAuthUrl() {
+      try {
+        const response = await get_request('linkedin/auth-url/');
+        return { success: true, data: response.data };
+      } catch (error) {
+        console.error('Error fetching LinkedIn auth URL:', error);
+        return { success: false };
+      }
+    },
+
+    /**
+     * linkedinCallback: Exchange authorization code for token.
+     * @param {string} code - Authorization code from LinkedIn redirect.
+     * @param {string} state - OAuth CSRF state parameter.
+     */
+    async linkedinCallback(code, state) {
+      try {
+        const response = await create_request('linkedin/callback/', { code, state });
+        return { success: true, data: response.data };
+      } catch (error) {
+        console.error('Error exchanging LinkedIn code:', error);
+        return { success: false, error: error.response?.data?.error };
+      }
+    },
+
+    /**
+     * publishToLinkedIn: Publish a blog post summary to LinkedIn.
+     * @param {number} postId - Blog post ID.
+     * @param {string} lang - Language for the summary ('es' or 'en').
+     */
+    async publishToLinkedIn(postId, lang = 'es') {
+      this.isUpdating = true;
+      try {
+        const response = await create_request(`blog/admin/${postId}/publish-linkedin/`, { lang });
+        return { success: true, data: response.data };
+      } catch (error) {
+        console.error('Error publishing to LinkedIn:', error);
+        return { success: false, error: error.response?.data?.error || 'Unknown error' };
+      /* c8 ignore next 3 */
+      } finally {
+        this.isUpdating = false;
+      }
+    },
   },
 });


### PR DESCRIPTION
Add OAuth 2.0 integration with LinkedIn to publish blog post summaries directly from the admin panel. Includes encrypted token storage (Fernet), CSRF state validation on OAuth callback, 10-min rate limiting on the publish endpoint, and automatic token refresh.

- New BlogPost fields: linkedin_summary_es/en, linkedin_post_id, linkedin_published_at
- New LinkedInToken singleton model with Fernet-encrypted access/refresh tokens
- LinkedIn service: OAuth flow, encrypted DB storage, auto-refresh, publishing
- LinkedIn views: auth URL with state, callback with validation, status, publish
- Frontend: summary fields in blog edit, LinkedIn connect/publish UI, OAuth callback page
- Redis cache backend (falls back to LocMemCache when CACHE_REDIS_URL is empty)
- 31 unit tests covering service layer and views