### PR TITLE
FIX: upgrade LinkedIn API to v202603, add image upload and auto-publish

### DIFF
--- a/backend/content/services/linkedin_service.py
+++ b/backend/content/services/linkedin_service.py
@@ -5,11 +5,13 @@ Handles:
 - OAuth 2.0 authorization code flow (3-legged)
 - Encrypted token storage via LinkedInToken singleton model
 - Automatic token refresh when access token expires
+- Image upload via LinkedIn Images API
 - Publishing blog post summaries with cover images to LinkedIn
 
 LinkedIn API docs:
   - Auth: https://learn.microsoft.com/en-us/linkedin/shared/authentication/authorization-code-flow
-  - Posts: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api
+  - Posts: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/posts-api?view=li-lms-2026-03
+  - Images: https://learn.microsoft.com/en-us/linkedin/marketing/community-management/shares/images-api?view=li-lms-2026-03
 """
 
 import logging
@@ -30,12 +32,23 @@ LINKEDIN_AUTH_URL = 'https://www.linkedin.com/oauth/v2/authorization'
 LINKEDIN_TOKEN_URL = 'https://www.linkedin.com/oauth/v2/accessToken'
 LINKEDIN_USERINFO_URL = 'https://api.linkedin.com/v2/userinfo'
 LINKEDIN_POSTS_URL = 'https://api.linkedin.com/rest/posts'
+LINKEDIN_IMAGES_URL = 'https://api.linkedin.com/rest/images'
 
 LINKEDIN_SCOPES = 'openid profile email w_member_social'
-LINKEDIN_API_VERSION = '202401'
+LINKEDIN_API_VERSION = '202603'
 
 # LinkedIn refresh tokens last 60 days
 _REFRESH_TOKEN_LIFETIME_DAYS = 60
+
+
+def _api_headers(access_token: str, content_type: str = 'application/json') -> dict:
+    """Standard headers for LinkedIn REST API calls."""
+    return {
+        'Authorization': f'Bearer {access_token}',
+        'Content-Type': content_type,
+        'X-Restli-Protocol-Version': '2.0.0',
+        'LinkedIn-Version': LINKEDIN_API_VERSION,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -115,7 +128,6 @@ def _refresh_access_token() -> str | None:
     token.set_access_token(data['access_token'])
     token.expires_at = now + timedelta(seconds=data.get('expires_in', 5_184_000))
     token.obtained_at = now
-    # LinkedIn does not rotate refresh tokens on refresh
     token.save()
 
     logger.info('LinkedIn access token refreshed — new expiry %s.', token.expires_at)
@@ -262,6 +274,81 @@ def get_member_urn() -> str | None:
 
 
 # ---------------------------------------------------------------------------
+# Image upload (LinkedIn Images API)
+# ---------------------------------------------------------------------------
+
+def _upload_image_to_linkedin(image_url: str) -> str | None:
+    """
+    Download an image from a URL and upload it to LinkedIn.
+
+    Flow:
+    1. Download image bytes from the given URL (e.g., Unsplash)
+    2. Initialize upload via LinkedIn Images API
+    3. Upload binary to the provided upload URL
+    4. Return the image URN (urn:li:image:XXX)
+
+    Returns the image URN string on success, None on failure.
+    """
+    access_token = get_access_token()
+    if not access_token:
+        logger.error('Cannot upload image — not connected to LinkedIn.')
+        return None
+
+    member_urn = get_member_urn()
+    if not member_urn:
+        logger.error('Cannot upload image — no member URN.')
+        return None
+
+    # Step 1: Download image from URL
+    try:
+        img_resp = requests.get(image_url, timeout=30, stream=True)
+        img_resp.raise_for_status()
+        image_bytes = img_resp.content
+        content_type = img_resp.headers.get('Content-Type', 'image/jpeg')
+    except requests.RequestException as exc:
+        logger.error('Failed to download image from %s: %s', image_url, exc)
+        return None
+
+    # Step 2: Initialize upload with LinkedIn
+    init_resp = requests.post(
+        f'{LINKEDIN_IMAGES_URL}?action=initializeUpload',
+        json={'initializeUploadRequest': {'owner': member_urn}},
+        headers=_api_headers(access_token),
+        timeout=15,
+    )
+
+    if init_resp.status_code != 200:
+        logger.error('LinkedIn image init failed: %s %s', init_resp.status_code, init_resp.text)
+        return None
+
+    init_data = init_resp.json().get('value', {})
+    upload_url = init_data.get('uploadUrl')
+    image_urn = init_data.get('image')
+
+    if not upload_url or not image_urn:
+        logger.error('LinkedIn image init response missing uploadUrl or image URN.')
+        return None
+
+    # Step 3: Upload binary image
+    upload_resp = requests.put(
+        upload_url,
+        data=image_bytes,
+        headers={
+            'Authorization': f'Bearer {access_token}',
+            'Content-Type': content_type,
+        },
+        timeout=60,
+    )
+
+    if upload_resp.status_code not in (200, 201):
+        logger.error('LinkedIn image upload failed: %s %s', upload_resp.status_code, upload_resp.text)
+        return None
+
+    logger.info('Image uploaded to LinkedIn: %s', image_urn)
+    return image_urn
+
+
+# ---------------------------------------------------------------------------
 # Publishing
 # ---------------------------------------------------------------------------
 
@@ -270,15 +357,17 @@ def publish_blog_to_linkedin(
     blog_url: str,
     title: str,
     cover_image_url: str = '',
+    description: str = '',
 ) -> dict:
     """
-    Publish a blog post summary to LinkedIn as a link share.
+    Publish a blog post summary to LinkedIn as an article share.
 
     Args:
-        summary: The text content for the LinkedIn post.
+        summary: The text content for the LinkedIn post (commentary).
         blog_url: Full URL to the blog post on projectapp.co.
         title: Title of the blog post (used in the article preview).
-        cover_image_url: URL of the cover image for the article thumbnail.
+        cover_image_url: URL of the cover image (downloaded and uploaded to LinkedIn).
+        description: Short description for the article preview.
 
     Returns:
         dict with 'success', 'post_id' (LinkedIn URN), and 'message'.
@@ -297,7 +386,23 @@ def publish_blog_to_linkedin(
     if not summary:
         raise ValueError('Summary text is required for LinkedIn post.')
 
-    # Build the post payload (LinkedIn Posts API v2)
+    # Upload cover image to LinkedIn if available
+    image_urn = None
+    if cover_image_url:
+        image_urn = _upload_image_to_linkedin(cover_image_url)
+        if not image_urn:
+            logger.warning('Image upload failed, publishing article without thumbnail.')
+
+    # Build the post payload (LinkedIn Posts API v2026-03)
+    article = {
+        'source': blog_url,
+        'title': title,
+    }
+    if description:
+        article['description'] = description
+    if image_urn:
+        article['thumbnail'] = image_urn
+
     post_data = {
         'author': member_urn,
         'commentary': summary,
@@ -308,30 +413,16 @@ def publish_blog_to_linkedin(
             'thirdPartyDistributionChannels': [],
         },
         'content': {
-            'article': {
-                'source': blog_url,
-                'title': title,
-            },
+            'article': article,
         },
         'lifecycleState': 'PUBLISHED',
         'isReshareDisabledByAuthor': False,
     }
 
-    # Add thumbnail if cover image is available
-    if cover_image_url:
-        post_data['content']['article']['thumbnail'] = cover_image_url
-
-    headers = {
-        'Authorization': f'Bearer {access_token}',
-        'Content-Type': 'application/json',
-        'X-Restli-Protocol-Version': '2.0.0',
-        'LinkedIn-Version': LINKEDIN_API_VERSION,
-    }
-
     resp = requests.post(
         LINKEDIN_POSTS_URL,
         json=post_data,
-        headers=headers,
+        headers=_api_headers(access_token),
         timeout=15,
     )
 

--- a/backend/content/tests/services/test_linkedin_service.py
+++ b/backend/content/tests/services/test_linkedin_service.py
@@ -251,10 +251,11 @@ class TestRefreshAccessToken:
 class TestPublishBlogToLinkedin:
 
     @freeze_time(FROZEN_NOW)
+    @patch('content.services.linkedin_service._upload_image_to_linkedin', return_value='urn:li:image:C4E10test')
     @patch('content.services.linkedin_service.requests.post')
     @patch('content.services.linkedin_service.get_member_urn', return_value='urn:li:person:abc')
     @patch('content.services.linkedin_service.get_access_token', return_value='valid-token')
-    def test_successful_publish_returns_post_id(self, mock_token, mock_urn, mock_post):
+    def test_successful_publish_returns_post_id(self, mock_token, mock_urn, mock_post, mock_upload):
         mock_resp = MagicMock()
         mock_resp.status_code = 201
         mock_resp.headers = {'x-restli-id': 'urn:li:share:123456'}
@@ -264,12 +265,16 @@ class TestPublishBlogToLinkedin:
             summary='Test summary',
             blog_url='https://projectapp.co/blog/test',
             title='Test Post',
-            cover_image_url='https://example.com/img.jpg',
+            cover_image_url='https://images.unsplash.com/photo-test',
         )
 
         assert result['success'] is True
         assert result['post_id'] == 'urn:li:share:123456'
+        mock_upload.assert_called_once_with('https://images.unsplash.com/photo-test')
         mock_post.assert_called_once()
+        # Verify the thumbnail is the image URN, not the raw URL
+        call_payload = mock_post.call_args[1]['json']
+        assert call_payload['content']['article']['thumbnail'] == 'urn:li:image:C4E10test'
 
     @patch('content.services.linkedin_service.get_access_token', return_value=None)
     def test_raises_when_not_connected(self, mock_token):

--- a/backend/content/tests/views/test_document_views.py
+++ b/backend/content/tests/views/test_document_views.py
@@ -312,7 +312,9 @@ class TestDuplicateDocument:
         assert response.status_code == 201
         data = response.json()
         assert '(copia)' in data['title']
-        assert data['document_type'] is not None
+        # document_type is not in the serializer response, verify via DB
+        duplicate = Document.objects.get(pk=data['id'])
+        assert duplicate.document_type is not None
 
 
 # ── download_document_pdf ──

--- a/backend/content/tests/views/test_linkedin_views.py
+++ b/backend/content/tests/views/test_linkedin_views.py
@@ -13,6 +13,7 @@ from django.utils import timezone
 from freezegun import freeze_time
 
 from content.models import BlogPost
+from content.serializers.blog import BLOG_JSON_TEMPLATE
 
 pytestmark = pytest.mark.django_db
 
@@ -197,3 +198,44 @@ class TestPublishToLinkedin:
         response = admin_client.post(url, {'lang': 'es'}, format='json')
         assert response.status_code == 200
         assert response.data['success'] is True
+
+
+# ---------------------------------------------------------------------------
+# TestAutoPublishOnBlogCreate
+# ---------------------------------------------------------------------------
+
+class TestAutoPublishOnBlogCreate:
+
+    @patch('content.views.blog._auto_publish_to_linkedin')
+    def test_calls_auto_publish_when_created_published_with_summary(self, mock_auto, admin_client):
+        payload = {
+            'title_es': 'Auto post',
+            'title_en': 'Auto post EN',
+            'excerpt_es': 'Extracto.',
+            'excerpt_en': 'Excerpt.',
+            'content_json_es': BLOG_JSON_TEMPLATE,
+            'is_published': True,
+            'linkedin_summary_es': 'Resumen para LinkedIn.',
+        }
+        response = admin_client.post(
+            reverse('create-blog-post-from-json'), payload, format='json',
+        )
+        assert response.status_code == 201
+        mock_auto.assert_called_once()
+
+    @patch('content.views.blog._auto_publish_to_linkedin')
+    def test_calls_auto_publish_for_draft_but_returns_early(self, mock_auto, admin_client):
+        payload = {
+            'title_es': 'Draft post',
+            'title_en': 'Draft EN',
+            'excerpt_es': 'Extracto.',
+            'excerpt_en': 'Excerpt.',
+            'content_json_es': BLOG_JSON_TEMPLATE,
+            'is_published': False,
+            'linkedin_summary_es': 'Resumen.',
+        }
+        response = admin_client.post(
+            reverse('create-blog-post-from-json'), payload, format='json',
+        )
+        assert response.status_code == 201
+        mock_auto.assert_called_once()

--- a/backend/content/views/blog.py
+++ b/backend/content/views/blog.py
@@ -5,6 +5,7 @@ from xml.sax.saxutils import escape as xml_escape
 
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
+from django.utils import timezone as tz
 from django.utils.dateparse import parse_date
 from rest_framework import status
 from rest_framework.decorators import api_view, parser_classes, permission_classes
@@ -24,8 +25,61 @@ from content.serializers.blog import (
     BLOG_JSON_TEMPLATE,
 )
 
+logger = logging.getLogger(__name__)
 
 BASE_URL = 'https://projectapp.co'
+BLOG_PUBLIC_BASE = f'{BASE_URL}/blog'
+
+
+def _auto_publish_to_linkedin(post):
+    """
+    Publish a blog post to LinkedIn if conditions are met:
+    - Post is published (is_published=True)
+    - Has a linkedin_summary (es or en)
+    - Has not been published to LinkedIn yet (no linkedin_post_id)
+
+    Runs silently — logs errors but never raises.
+    """
+    if not post.is_published:
+        return
+    if post.linkedin_post_id:
+        return
+
+    summary = post.linkedin_summary_es or post.linkedin_summary_en
+    if not summary:
+        return
+
+    lang = 'es' if post.linkedin_summary_es else 'en'
+    title = post.title_es if lang == 'es' else post.title_en
+
+    # Get cover image URL
+    cover_image_url = ''
+    if post.cover_image_url:
+        cover_image_url = post.cover_image_url
+    elif post.cover_image:
+        cover_image_url = f'{BASE_URL}{post.cover_image.url}'
+
+    blog_url = f'{BLOG_PUBLIC_BASE}/{post.slug}'
+
+    try:
+        from content.services.linkedin_service import publish_blog_to_linkedin
+
+        result = publish_blog_to_linkedin(
+            summary=summary,
+            blog_url=blog_url,
+            title=title,
+            cover_image_url=cover_image_url,
+            description=post.excerpt_es if lang == 'es' else post.excerpt_en,
+        )
+        if result['success']:
+            post.linkedin_post_id = result['post_id']
+            post.linkedin_published_at = tz.now()
+            post.save(update_fields=['linkedin_post_id', 'linkedin_published_at'])
+            logger.info('Auto-published blog "%s" to LinkedIn: %s', post.slug, result['post_id'])
+        else:
+            logger.warning('LinkedIn auto-publish failed for "%s": %s', post.slug, result['message'])
+    except Exception:
+        logger.exception('LinkedIn auto-publish error for blog "%s"', post.slug)
 
 STATIC_SITEMAP_PAGES = [
     ('/en-us', '/es-co', 'weekly', '1.0'),
@@ -230,6 +284,7 @@ def create_blog_post(request):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     post = serializer.save()
+    _auto_publish_to_linkedin(post)
     detail = BlogPostAdminDetailSerializer(post)
     return Response(detail.data, status=status.HTTP_201_CREATED)
 
@@ -253,6 +308,7 @@ def update_blog_post(request, post_id):
     Update a blog post's fields.
     """
     post = get_object_or_404(BlogPost, pk=post_id)
+    was_published = post.is_published
     serializer = BlogPostCreateUpdateSerializer(
         post, data=request.data, partial=True
     )
@@ -260,6 +316,9 @@ def update_blog_post(request, post_id):
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
 
     serializer.save()
+    # Auto-publish to LinkedIn when post transitions to published
+    if post.is_published and not was_published:
+        _auto_publish_to_linkedin(post)
     detail = BlogPostAdminDetailSerializer(post)
     return Response(detail.data, status=status.HTTP_200_OK)
 
@@ -315,6 +374,7 @@ def create_blog_post_from_json(request):
         linkedin_summary_en=data.get('linkedin_summary_en', ''),
     )
 
+    _auto_publish_to_linkedin(post)
     detail = BlogPostAdminDetailSerializer(post)
     return Response(detail.data, status=status.HTTP_201_CREATED)
 

--- a/backend/content/views/linkedin.py
+++ b/backend/content/views/linkedin.py
@@ -165,12 +165,15 @@ def publish_to_linkedin(request, post_id):
     elif post.cover_image:
         cover_image_url = f'https://projectapp.co{post.cover_image.url}'
 
+    description = post.excerpt_es if lang == 'es' else post.excerpt_en
+
     try:
         result = publish_blog_to_linkedin(
             summary=summary,
             blog_url=blog_url,
             title=title,
             cover_image_url=cover_image_url,
+            description=description,
         )
     except ValueError as exc:
         return Response(


### PR DESCRIPTION
- Update LINKEDIN_API_VERSION from 202401 (sunset) to 202603
- Add _upload_image_to_linkedin: downloads image from URL (e.g. Unsplash), uploads to LinkedIn Images API, returns image URN for article thumbnail
- Add _auto_publish_to_linkedin: publishes to LinkedIn automatically when a blog post is created/updated as published with a linkedin_summary
- Auto-publish triggers on create_blog_post, create_blog_post_from_json, and update_blog_post (only on draft→published transition)
- Add description field to article share payload
- Update tests: mock image upload, add auto-publish tests