### PR TITLE
FIX: align --color-text-brand with brand esmerald in light mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,11 @@
 - Do not change old migrations; add new migrations when schema changes are required.
 - Keep security basics intact: validated serializer inputs, ORM-first queries, escaped rendering, CSRF/session boundaries, and no secrets in code.
 
+## Commit & PR Authorship
+- Do NOT add `Co-Authored-By: Claude ...` trailers to commit messages. The repository owner is the sole author.
+- Do NOT include "Generated with Claude Code", "🤖 Generated with..." footers, or any similar attribution line in commit messages or PR bodies.
+- Write commit messages and PR descriptions in the project's normal voice (FIX/FEAT/REFACTOR prefixes, plain summary + test plan), with no AI-tooling attribution.
+
 ## Commands
 - Backend tests: `source .venv/bin/activate && cd backend && pytest path/to/test_file.py -v`
 - Backend dev server: `source .venv/bin/activate && cd backend && python manage.py runserver`

--- a/frontend/assets/styles/theme.css
+++ b/frontend/assets/styles/theme.css
@@ -85,13 +85,13 @@
   --color-text: #111827;             /* gray-900 */
   --color-text-muted: #6B7280;       /* gray-500 */
   --color-text-subtle: #9CA3AF;      /* gray-400 */
-  --color-text-brand: #047857;       /* emerald-700 — for legends, brand-tinted headings */
+  --color-text-brand: #002921;       /* esmerald — brand */
 
   /* Text RGB triplets — light */
   --color-text-rgb: 17 24 39;        /* #111827 */
   --color-text-muted-rgb: 107 114 128; /* #6B7280 */
   --color-text-subtle-rgb: 156 163 175; /* #9CA3AF */
-  --color-text-brand-rgb: 4 120 87;  /* #047857 */
+  --color-text-brand-rgb: 0 41 33;   /* #002921 */
 
   /* Form controls — light */
   --color-input-bg: #FFFFFF;


### PR DESCRIPTION
## Summary
- Light-mode `--color-text-brand` was set to emerald-700 (`#047857`) during the design-system migration (commit `d2119b95`), which made every `text-text-brand` heading, badge and icon across the app read as a generic green instead of the brand esmerald (`#002921`).
- Realign the token and its RGB triplet to the brand hex so all migrated surfaces recover the correct identity color in light mode.
- Dark-mode token is left untouched (kept as emerald-300) for legibility on dark surfaces.

## Test plan
- [ ] Open `/` (home) in light mode and verify the hero `<span class="text-text-brand">` reads as esmerald `#002921`, not emerald-700.
- [ ] Spot-check landings (`/landing-software`, `/landing-apps`), blog `/blog/[slug]`, portfolio `/portfolio-works/[slug]` headings.
- [ ] Spot-check panel pages that use `text-text-brand` (`/panel`, `/panel/proposals/[id]/edit`, `/panel/styleguide`).
- [ ] Toggle dark mode on the panel and confirm headings still read correctly (emerald-300).
- [ ] Confirm `text-text-brand/40` opacity modifiers still compose correctly (token still uses the RGB triplet bridge).