### PR TITLE
CHORE: corregir path ops/vps → vps-ops-toolkit en skills y hooks

### DIFF
--- a/.agents/skills/deploy-and-check/SKILL.md
+++ b/.agents/skills/deploy-and-check/SKILL.md
@@ -8,7 +8,7 @@ argument-hint: "[branch-name (opcional — default: rama actual del repo)]"
 
 # Deploy & Check — Generic
 
-Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/projects.yml`). Funciona para staging y producción.
+Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/vps-ops-toolkit/projects.yml`). Funciona para staging y producción.
 
 - **Stack**: Django + Gunicorn + Nginx + (MySQL 8 | SQLite) + Redis + Huey
 - **Frontends soportados**: Vite (build estático), Next.js export (estático), Next.js SSR
@@ -27,7 +27,7 @@ Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/
 ```bash
 PROJECT_DIR=$(pwd)
 PROJECT_NAME=$(basename "$PROJECT_DIR")
-OPS_YML="$HOME/webapps/ops/vps/projects.yml"
+OPS_YML="$HOME/webapps/vps-ops-toolkit/projects.yml"
 [ -f "$OPS_YML" ] || { echo "❌ ERROR: $OPS_YML no encontrado"; exit 1; }
 
 yml_get() {
@@ -79,7 +79,7 @@ EOF
 
 1. Salud del servidor:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/diagnostics/quick-status.sh
+bash $HOME/webapps/vps-ops-toolkit/scripts/diagnostics/quick-status.sh
 ```
 
 2. Working tree limpio:
@@ -168,7 +168,7 @@ cd "$PROJECT_DIR" && git log --oneline -1
 
 12. Post-deploy check del repo ops:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
+bash $HOME/webapps/vps-ops-toolkit/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
 ```
 
 ---
@@ -193,6 +193,6 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 
 ## Notas
 
-- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/ops/vps/projects.yml`. Funciona para staging y producción.
+- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
-- Fuente canónica: `ops/vps/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+- Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.

--- a/.agents/skills/fake-data-refresh/SKILL.md
+++ b/.agents/skills/fake-data-refresh/SKILL.md
@@ -50,7 +50,7 @@ IN_FLEET=false
 # - En cualquier otro caso (production explícita, sin field environment, etc.) → Signal A.
 # Esto cubre el caso de proyectos production sin field `environment:` (ej. kore_project),
 # donde el helper devuelve default=production por convención.
-OPS_ROOT=/home/ryzepeck/webapps/ops/vps
+OPS_ROOT=/home/ryzepeck/webapps/vps-ops-toolkit
 if [ -f "${OPS_ROOT}/projects.yml" ]; then
   MODE=check
   # shellcheck source=/dev/null

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "timeout 20 bash /home/ryzepeck/webapps/ops/vps/scripts/maintenance/session-start-git-status.sh 2>&1 || true"
+            "command": "timeout 20 bash /home/ryzepeck/webapps/vps-ops-toolkit/scripts/maintenance/session-start-git-status.sh 2>&1 || true"
           }
         ]
       }
@@ -31,7 +31,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "timeout 10 bash /home/ryzepeck/webapps/ops/vps/scripts/maintenance/stop-check-user-flows.sh 2>&1 || true"
+            "command": "timeout 10 bash /home/ryzepeck/webapps/vps-ops-toolkit/scripts/maintenance/stop-check-user-flows.sh 2>&1 || true"
           }
         ]
       }

--- a/.claude/skills/deploy-and-check/SKILL.md
+++ b/.claude/skills/deploy-and-check/SKILL.md
@@ -29,7 +29,7 @@ Si el bloque aborta con ❌, **NO continuar** con las fases siguientes — SSH a
 
 # Deploy & Check — Generic
 
-Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/projects.yml`). Funciona para staging y producción.
+Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/vps-ops-toolkit/projects.yml`). Funciona para staging y producción.
 
 - **Stack**: Django + Gunicorn + Nginx + (MySQL 8 | SQLite) + Redis + Huey
 - **Frontends soportados**: Vite (build estático), Next.js export (estático), Next.js SSR
@@ -48,7 +48,7 @@ Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/
 ```bash
 PROJECT_DIR=$(pwd)
 PROJECT_NAME=$(basename "$PROJECT_DIR")
-OPS_YML="$HOME/webapps/ops/vps/projects.yml"
+OPS_YML="$HOME/webapps/vps-ops-toolkit/projects.yml"
 [ -f "$OPS_YML" ] || { echo "❌ ERROR: $OPS_YML no encontrado"; exit 1; }
 
 yml_get() {
@@ -100,7 +100,7 @@ EOF
 
 1. Salud del servidor:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/diagnostics/quick-status.sh
+bash $HOME/webapps/vps-ops-toolkit/scripts/diagnostics/quick-status.sh
 ```
 
 2. Working tree limpio:
@@ -189,7 +189,7 @@ cd "$PROJECT_DIR" && git log --oneline -1
 
 12. Post-deploy check del repo ops:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
+bash $HOME/webapps/vps-ops-toolkit/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
 ```
 
 ---
@@ -214,6 +214,6 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 
 ## Notas
 
-- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/ops/vps/projects.yml`. Funciona para staging y producción.
+- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
-- Fuente canónica: `ops/vps/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+- Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.

--- a/.claude/skills/fake-data-refresh/SKILL.md
+++ b/.claude/skills/fake-data-refresh/SKILL.md
@@ -50,7 +50,7 @@ IN_FLEET=false
 # - En cualquier otro caso (production explícita, sin field environment, etc.) → Signal A.
 # Esto cubre el caso de proyectos production sin field `environment:` (ej. kore_project),
 # donde el helper devuelve default=production por convención.
-OPS_ROOT=/home/ryzepeck/webapps/ops/vps
+OPS_ROOT=/home/ryzepeck/webapps/vps-ops-toolkit
 if [ -f "${OPS_ROOT}/projects.yml" ]; then
   MODE=check
   # shellcheck source=/dev/null

--- a/.claude/skills/playwright-validation/SKILL.md
+++ b/.claude/skills/playwright-validation/SKILL.md
@@ -38,7 +38,7 @@ Si la solicitud encaja en cualquiera de estos, ejecutar el flujo de pre-flight c
 
 ```bash
 # Cargar helpers del fleet (idéntico al patrón que usan server-alerts.sh, backup-mysql-and-media.sh)
-OPS_ROOT=/home/ryzepeck/webapps/ops/vps
+OPS_ROOT=/home/ryzepeck/webapps/vps-ops-toolkit
 MODE=check
 source "${OPS_ROOT}/scripts/lib/bootstrap-common.sh"
 source "${OPS_ROOT}/scripts/lib/project-definitions.sh"

--- a/.windsurf/workflows/deploy-and-check.md
+++ b/.windsurf/workflows/deploy-and-check.md
@@ -8,7 +8,7 @@ argument-hint: "[branch-name (opcional — default: rama actual del repo)]"
 
 # Deploy & Check — Generic
 
-Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/projects.yml`). Funciona para staging y producción.
+Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/vps-ops-toolkit/projects.yml`). Funciona para staging y producción.
 
 - **Stack**: Django + Gunicorn + Nginx + (MySQL 8 | SQLite) + Redis + Huey
 - **Frontends soportados**: Vite (build estático), Next.js export (estático), Next.js SSR
@@ -27,7 +27,7 @@ Despliegue del proyecto actual (auto-detectado desde `pwd` + `~/webapps/ops/vps/
 ```bash
 PROJECT_DIR=$(pwd)
 PROJECT_NAME=$(basename "$PROJECT_DIR")
-OPS_YML="$HOME/webapps/ops/vps/projects.yml"
+OPS_YML="$HOME/webapps/vps-ops-toolkit/projects.yml"
 [ -f "$OPS_YML" ] || { echo "❌ ERROR: $OPS_YML no encontrado"; exit 1; }
 
 yml_get() {
@@ -79,7 +79,7 @@ EOF
 
 1. Salud del servidor:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/diagnostics/quick-status.sh
+bash $HOME/webapps/vps-ops-toolkit/scripts/diagnostics/quick-status.sh
 ```
 
 2. Working tree limpio:
@@ -168,7 +168,7 @@ cd "$PROJECT_DIR" && git log --oneline -1
 
 12. Post-deploy check del repo ops:
 ```bash
-bash $HOME/webapps/ops/vps/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
+bash $HOME/webapps/vps-ops-toolkit/scripts/deployment/post-deploy-check.sh "$PROJECT_NAME"
 ```
 
 ---
@@ -193,6 +193,6 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 
 ## Notas
 
-- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/ops/vps/projects.yml`. Funciona para staging y producción.
+- Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
-- Fuente canónica: `ops/vps/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+- Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.

--- a/.windsurf/workflows/deploy.md
+++ b/.windsurf/workflows/deploy.md
@@ -11,7 +11,7 @@ Run these steps on the production server at `/home/ryzepeck/webapps/azurita` to 
 // turbo
 1. Quick status snapshot before deploy:
 ```bash
-bash /home/ryzepeck/webapps/ops/vps/scripts/diagnostics/quick-status.sh
+bash /home/ryzepeck/webapps/vps-ops-toolkit/scripts/diagnostics/quick-status.sh
 ```
 
 ## Deploy Steps
@@ -55,7 +55,7 @@ sudo systemctl restart azurita && sudo systemctl restart azurita-huey
 
 ## Notes
 
-- VPS operations scripts live in `/home/ryzepeck/webapps/ops/vps/scripts/`.
+- VPS operations scripts live in `/home/ryzepeck/webapps/vps-ops-toolkit/scripts/`.
 - azurita uses SQLite (lightweight project).
 - `manage.py` is at the repo root; `venv/` is at the repo root too.
 - WorkingDirectory for gunicorn is `/home/ryzepeck/webapps/azurita`.

--- a/.windsurf/workflows/fake-data-refresh.md
+++ b/.windsurf/workflows/fake-data-refresh.md
@@ -48,7 +48,7 @@ IN_FLEET=false
 # - En cualquier otro caso (production explícita, sin field environment, etc.) → Signal A.
 # Esto cubre el caso de proyectos production sin field `environment:` (ej. kore_project),
 # donde el helper devuelve default=production por convención.
-OPS_ROOT=/home/ryzepeck/webapps/ops/vps
+OPS_ROOT=/home/ryzepeck/webapps/vps-ops-toolkit
 if [ -f "${OPS_ROOT}/projects.yml" ]; then
   MODE=check
   # shellcheck source=/dev/null

--- a/.windsurf/workflows/full-audit.md
+++ b/.windsurf/workflows/full-audit.md
@@ -54,7 +54,7 @@ Flags disponibles: `--with-backup-test`, `--send-email`, `--quiet`, `--skip-env-
 
 ## Pasos
 
-1. Verificar que estás parado en el root del repo (`/home/ryzepeck/webapps/ops/vps`).
+1. Verificar que estás parado en el root del repo (`/home/ryzepeck/webapps/vps-ops-toolkit`).
 2. Ejecutar el orquestador con los flags deseados.
 3. Una vez termine, abrir el reporte generado en `docs/audits/` y reportar al usuario: veredicto global, fases fallidas/warn con sus resúmenes, y próximos pasos si el veredicto no es 🟢.
 4. Si hay 🔴 o 🟡, abrir el log crudo y proponer remediaciones priorizadas.


### PR DESCRIPTION
Actualiza 10 archivos (.claude/skills, .agents/skills, .windsurf/workflows, .claude/settings.json) que referenciaban el path obsoleto /home/ryzepeck/webapps/ops/vps. El path correcto es vps-ops-toolkit. Fixes el error del hook SessionStart al inicio de cada sesión.