### PR TITLE
chore: language convention → English

### DIFF
--- a/.windsurf/rules/always-on.md
+++ b/.windsurf/rules/always-on.md
@@ -8,7 +8,7 @@ trigger: always_on
 
 ## Convencion de lenguaje
 
-- Documentacion, comentarios y mensajes de commit en **espanol**.
+- Documentacion, comentarios y mensajes de commit en **ingles**.
 - Codigo, identificadores y nombres de variable en **ingles**.
 - Mensajes de error visibles al usuario en el idioma del proyecto.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ la seccion `project-specific` mas abajo.
 
 ## Convencion de lenguaje
 
-- Documentacion, comentarios y mensajes de commit en **espanol**.
+- Documentacion, comentarios y mensajes de commit en **ingles**.
 - Codigo, identificadores y nombres de variable en **ingles**.
 - Mensajes de error visibles al usuario final en el idioma del proyecto.
 


### PR DESCRIPTION
Switches the **Convencion de lenguaje** block so documentation, comments and commit messages are now in English (matching code/identifiers). No code changes — docs/AI-config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)