### PR TITLE
FIX: responsive de la plataforma (lista de proyectos, vistas de proyecto, clientes y sidebar móvil)

### DIFF
--- a/backend/accounts/tests/test_views_coverage_gaps.py
+++ b/backend/accounts/tests/test_views_coverage_gaps.py
@@ -271,6 +271,22 @@ class TestProposalListForSelectorView:
         assert len(data) == 1
         assert data[0]['title'] == 'Open Proposal'
 
+    def test_includes_finished_proposals_without_deliverable(
+        self, api_client, admin_headers,
+    ):
+        from content.models import BusinessProposal
+
+        BusinessProposal.objects.create(
+            title='Finished Proposal', status='finished', slug='finished-prop',
+        )
+
+        resp = api_client.get('/api/accounts/proposals/', **admin_headers)
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert len(data) == 1
+        assert data[0]['title'] == 'Finished Proposal'
+
     def test_excludes_proposals_with_deliverable_linked(
         self, api_client, admin_headers, admin_user, client_user,
     ):

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -3183,7 +3183,7 @@ def proposal_list_for_selector_view(request):
     from content.models import BusinessProposal
 
     qs = BusinessProposal.objects.filter(
-        status__in=['accepted', 'sent', 'viewed', 'negotiating'],
+        status__in=['accepted', 'finished', 'sent', 'viewed', 'negotiating'],
         deliverable__isnull=True,
     ).order_by('-created_at')
 

--- a/frontend/components/platform/PlatformMobileDrawer.vue
+++ b/frontend/components/platform/PlatformMobileDrawer.vue
@@ -36,22 +36,9 @@
         <!-- Navigation (reuse sidebar items) -->
         <nav class="flex-1 overflow-y-auto px-3 py-4">
           <div class="mb-5">
-            <p class="mb-2 px-2 text-[10px] font-semibold uppercase tracking-widest text-green-light/60">Principal</p>
+            <p class="mb-2 px-2 text-[10px] font-semibold uppercase tracking-widest text-green-light/60">Navegación</p>
             <SidebarItem
               v-for="item in primaryItems"
-              :key="item.href"
-              :item="item"
-              :is-collapsed="false"
-              :is-active="isActive(item.href)"
-              :disabled="item.disabled"
-              @click="$emit('close')"
-            />
-          </div>
-
-          <div class="mb-5">
-            <p class="mb-2 px-2 text-[10px] font-semibold uppercase tracking-widest text-green-light/60">Proyectos</p>
-            <SidebarItem
-              v-for="item in projectItems"
               :key="item.href"
               :item="item"
               :is-collapsed="false"
@@ -137,7 +124,7 @@
 
             <button
               type="button"
-              class="ml-auto rounded-full border border-input-border/10 px-4 py-2 text-sm text-green-light transition hover:text-text-brand dark:border-white/10 dark:hover:text-white"
+              class="ml-auto rounded-full border border-input-border px-4 py-2 text-sm text-green-light transition hover:text-text-brand dark:border-white/10 dark:hover:text-white"
               @click="$emit('logout')"
             >
               Salir
@@ -152,11 +139,8 @@
 <script setup>
 import { computed } from 'vue'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
-import { usePlatformNotificationsStore } from '~/stores/platform-notifications'
 import SidebarItem from '~/components/platform/SidebarItem.vue'
-
-const localePath = useLocalePath()
-const lp = (path) => localePath(path)
+import { usePlatformNav } from '~/composables/usePlatformNav'
 
 defineEmits(['close', 'logout', 'toggleTheme', 'openThemePicker'])
 
@@ -165,71 +149,13 @@ const props = defineProps({
   isDark: { type: Boolean, default: true },
 })
 
-const route = useRoute()
 const authStore = usePlatformAuthStore()
-const notifStore = usePlatformNotificationsStore()
+
+const { primaryItems, accountItems, adminItems, isActive } = usePlatformNav()
 
 const userSubtitle = computed(() =>
   authStore.user?.company_name || authStore.user?.email || 'Portal ProjectApp',
 )
-
-const primaryItems = computed(() => [
-  { label: 'Dashboard', href: lp('/platform/dashboard'), icon: 'dashboard' },
-  { label: 'Notificaciones', href: lp('/platform/notifications'), icon: 'bell', badge: notifStore.unreadCount },
-])
-
-const projectItems = computed(() => {
-  if (authStore.isAdmin) {
-    return [
-      { label: 'Proyectos', href: lp('/platform/projects'), icon: 'folder' },
-      { label: 'Tablero', href: lp('/platform/board'), icon: 'board' },
-      { label: 'Solicitudes', href: lp('/platform/changes'), icon: 'refresh' },
-      { label: 'Bugs', href: lp('/platform/bugs'), icon: 'bug' },
-      { label: 'Entregables', href: lp('/platform/deliverables'), icon: 'file' },
-      { label: 'Pagos', href: lp('/platform/payments'), icon: 'credit-card' },
-    ]
-  }
-  return [
-    { label: 'Mis proyectos', href: lp('/platform/projects'), icon: 'folder' },
-    { label: 'Tablero', href: lp('/platform/board'), icon: 'board' },
-    { label: 'Solicitudes', href: lp('/platform/changes'), icon: 'refresh' },
-    { label: 'Bugs', href: lp('/platform/bugs'), icon: 'bug' },
-    { label: 'Entregables', href: lp('/platform/deliverables'), icon: 'file' },
-      { label: 'Pagos', href: lp('/platform/payments'), icon: 'credit-card' },
-  ]
-})
-
-const accountItems = computed(() => [
-  { label: 'Configuración', href: lp('/platform/profile'), icon: 'settings' },
-])
-
-const adminItems = computed(() => [
-  { label: 'Clientes', href: lp('/platform/clients'), icon: 'users' },
-])
-
-const projectSubModules = {
-  board: '/platform/board',
-  changes: '/platform/changes',
-  bugs: '/platform/bugs',
-  deliverables: '/platform/deliverables',
-  payments: '/platform/payments',
-}
-
-function isActive(href) {
-  const cleanPath = route.path.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
-  const cleanHref = href.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
-
-  const projectSubMatch = cleanPath.match(/^\/platform\/projects\/\d+\/([^/]+)/)
-  if (projectSubMatch) {
-    const subSection = projectSubMatch[1]
-    const mappedModule = projectSubModules[subSection]
-    if (mappedModule) {
-      return cleanHref === mappedModule
-    }
-  }
-
-  return cleanPath === cleanHref || cleanPath.startsWith(`${cleanHref}/`)
-}
 </script>
 
 <style scoped>

--- a/frontend/components/platform/PlatformSidebar.vue
+++ b/frontend/components/platform/PlatformSidebar.vue
@@ -184,8 +184,7 @@ import { computed, inject, onMounted, onUnmounted } from 'vue'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
 import { usePlatformNotificationsStore } from '~/stores/platform-notifications'
 import SidebarItem from '~/components/platform/SidebarItem.vue'
-
-const localePath = useLocalePath()
+import { usePlatformNav } from '~/composables/usePlatformNav'
 
 defineEmits(['logout'])
 
@@ -198,9 +197,10 @@ const toggleSidebar = inject('toggleSidebar')
 const toggleTheme = inject('toggleTheme')
 const showThemePicker = inject('showThemePicker')
 
-const route = useRoute()
 const authStore = usePlatformAuthStore()
 const notifStore = usePlatformNotificationsStore()
+
+const { primaryItems, accountItems, adminItems, isActive } = usePlatformNav()
 
 onMounted(() => { notifStore.startPolling(30000) })
 onUnmounted(() => { notifStore.stopPolling() })
@@ -215,34 +215,4 @@ const sidebarActionClass = computed(() => [
   'dark:hover:bg-surface/[0.06] dark:hover:text-white',
 ])
 
-const lp = (path) => localePath(path)
-
-const primaryItems = computed(() => {
-  const items = [
-    { label: 'Notificaciones', href: lp('/platform/notifications'), icon: 'bell', badge: notifStore.unreadCount },
-    { label: 'Proyectos',      href: lp('/platform/projects'),      icon: 'folder' },
-  ]
-  if (authStore.isAdmin) {
-    items.push({ label: 'Clientes', href: lp('/platform/clients'), icon: 'users' })
-  }
-  return items
-})
-
-// Kept for backwards compatibility with the template's section structure;
-// always empty after the IA refactor (modules now live inside each project).
-const projectItems = computed(() => [])
-
-const accountItems = computed(() => [
-  { label: 'Configuración', href: lp('/platform/profile'), icon: 'settings' },
-])
-
-const adminItems = computed(() => [
-  { label: 'Panel admin', href: '/panel', icon: 'external', external: true },
-])
-
-function isActive(href) {
-  const cleanPath = route.path.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
-  const cleanHref = href.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
-  return cleanPath === cleanHref || cleanPath.startsWith(`${cleanHref}/`)
-}
 </script>

--- a/frontend/components/platform/projects/PhaseList.vue
+++ b/frontend/components/platform/projects/PhaseList.vue
@@ -16,15 +16,15 @@
       @end="onReorderEnd"
     >
       <template #item="{ element }">
-        <div class="flex items-center gap-3 rounded-xl border border-border-muted bg-surface-muted/30 px-4 py-3">
-          <span v-if="authStore.isAdmin" class="drag-handle cursor-grab select-none text-green-light/40" aria-label="Arrastrar">⠿</span>
-          <span class="font-medium text-text-default">{{ element.order }}. {{ element.proposal.title }}</span>
-          <span class="ml-auto text-sm text-green-light/60">${{ element.proposal.total_amount }}</span>
+        <div class="flex items-center gap-2 rounded-xl border border-border-muted bg-surface-muted/30 px-3 py-3 sm:gap-3 sm:px-4">
+          <span v-if="authStore.isAdmin" class="drag-handle shrink-0 cursor-grab select-none text-green-light/40" aria-label="Arrastrar">⠿</span>
+          <span class="min-w-0 flex-1 truncate font-medium text-text-default">{{ element.order }}. {{ element.proposal.title }}</span>
+          <span class="shrink-0 text-sm text-green-light/60">${{ element.proposal.total_amount }}</span>
           <template v-if="authStore.isAdmin">
-            <button class="rounded-lg border border-border-default px-2 py-1 text-xs text-green-light" @click="onEditProposal(element.proposal.id)">Editar</button>
+            <button class="shrink-0 rounded-lg border border-border-default px-2 py-1 text-xs text-green-light" @click="onEditProposal(element.proposal.id)">Editar</button>
             <button
               :data-testid="`remove-phase-${element.id}`"
-              class="rounded-lg border border-red-500/30 px-2 py-1 text-xs text-red-600"
+              class="shrink-0 rounded-lg border border-red-500/30 px-2 py-1 text-xs text-red-600"
               @click="onRemove(element.id)"
             >×</button>
           </template>

--- a/frontend/components/platform/projects/ProjectSecondarySidebar.vue
+++ b/frontend/components/platform/projects/ProjectSecondarySidebar.vue
@@ -1,26 +1,28 @@
 <template>
-  <aside class="w-56 shrink-0 self-start rounded-3xl border border-border-default bg-surface px-3 py-4 shadow-sm">
-    <template v-for="item in items" :key="item.disabled ? item.label : item.href">
-      <span
-        v-if="item.disabled"
-        class="mb-1 flex cursor-not-allowed items-center justify-between gap-2 rounded-xl px-3 py-2 text-sm font-medium opacity-40"
-      >
-        {{ item.label }}
-        <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
-      </span>
-      <NuxtLink
-        v-else
-        :to="item.href"
-        :class="[
-          'mb-1 flex items-center gap-2 rounded-xl px-3 py-2 text-sm font-medium transition',
-          isActive(item.href)
-            ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
-            : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
-        ]"
-      >
-        {{ item.label }}
-      </NuxtLink>
-    </template>
+  <aside class="w-full shrink-0 self-start rounded-3xl border border-border-default bg-surface px-3 py-3 shadow-sm lg:w-56 lg:py-4">
+    <div class="flex gap-1 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible lg:pb-0">
+      <template v-for="item in items" :key="item.disabled ? item.label : item.href">
+        <span
+          v-if="item.disabled"
+          class="flex shrink-0 cursor-not-allowed items-center justify-between gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium opacity-40"
+        >
+          {{ item.label }}
+          <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
+        </span>
+        <NuxtLink
+          v-else
+          :to="item.href"
+          :class="[
+            'flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium transition',
+            isActive(item.href)
+              ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
+              : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
+          ]"
+        >
+          {{ item.label }}
+        </NuxtLink>
+      </template>
+    </div>
   </aside>
 </template>
 

--- a/frontend/components/platform/projects/ProjectSecondarySidebar.vue
+++ b/frontend/components/platform/projects/ProjectSecondarySidebar.vue
@@ -1,33 +1,59 @@
 <template>
   <aside class="w-full shrink-0 self-start rounded-3xl border border-border-default bg-surface px-3 py-3 shadow-sm lg:w-56 lg:py-4">
-    <div class="flex gap-1 overflow-x-auto pb-1 lg:flex-col lg:overflow-visible lg:pb-0">
-      <template v-for="item in items" :key="item.disabled ? item.label : item.href">
-        <span
-          v-if="item.disabled"
-          class="flex shrink-0 cursor-not-allowed items-center justify-between gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium opacity-40"
-        >
-          {{ item.label }}
-          <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
-        </span>
-        <NuxtLink
-          v-else
-          :to="item.href"
-          :class="[
-            'flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium transition',
-            isActive(item.href)
-              ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
-              : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
-          ]"
-        >
-          {{ item.label }}
-        </NuxtLink>
-      </template>
+    <div class="relative">
+      <!-- Edge fades (móvil): insinúan que hay más tabs ocultos -->
+      <div
+        v-show="showLeftFade"
+        class="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-surface to-transparent lg:hidden"
+      ></div>
+      <div
+        v-show="showRightFade"
+        class="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-surface to-transparent lg:hidden"
+      ></div>
+
+      <div
+        ref="scrollerRef"
+        class="flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible"
+        @scroll="updateScrollState"
+      >
+        <template v-for="item in items" :key="item.disabled ? item.label : item.href">
+          <span
+            v-if="item.disabled"
+            class="flex shrink-0 cursor-not-allowed items-center justify-between gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium opacity-40"
+          >
+            {{ item.label }}
+            <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
+          </span>
+          <NuxtLink
+            v-else
+            :to="item.href"
+            :data-active="isActive(item.href)"
+            :class="[
+              'flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium transition',
+              isActive(item.href)
+                ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
+                : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
+            ]"
+          >
+            {{ item.label }}
+          </NuxtLink>
+        </template>
+      </div>
+    </div>
+
+    <!-- Barrita indicadora de scroll (solo móvil, solo si hay overflow) -->
+    <div
+      v-show="hasOverflow"
+      class="mt-2 h-1 w-full overflow-hidden rounded-full bg-surface-muted lg:hidden"
+      aria-hidden="true"
+    >
+      <div class="h-full rounded-full bg-green-light/40" :style="thumbStyle"></div>
     </div>
   </aside>
 </template>
 
 <script setup>
-import { computed } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from 'vue'
 
 const props = defineProps({
   projectId: { type: [String, Number], required: true },
@@ -55,4 +81,63 @@ function isActive(href) {
   const stripped = (p) => p.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
   return stripped(route.path) === stripped(href)
 }
+
+// --- Indicadores de scroll horizontal (móvil) ---
+const scrollerRef = ref(null)
+const hasOverflow = ref(false)
+const showLeftFade = ref(false)
+const showRightFade = ref(false)
+const thumbWidthPct = ref(100)
+const thumbLeftPct = ref(0)
+
+const thumbStyle = computed(() => ({
+  width: `${thumbWidthPct.value}%`,
+  marginLeft: `${thumbLeftPct.value}%`,
+}))
+
+function updateScrollState() {
+  const el = scrollerRef.value
+  if (!el) return
+  const { scrollLeft, scrollWidth, clientWidth } = el
+  const max = scrollWidth - clientWidth
+  hasOverflow.value = max > 2
+  showLeftFade.value = scrollLeft > 2
+  showRightFade.value = scrollLeft < max - 2
+  thumbWidthPct.value = scrollWidth > 0 ? Math.min(100, (clientWidth / scrollWidth) * 100) : 100
+  thumbLeftPct.value = scrollWidth > 0 ? (scrollLeft / scrollWidth) * 100 : 0
+}
+
+function scrollActiveIntoView() {
+  const el = scrollerRef.value
+  if (!el) return
+  const active = el.querySelector('[data-active="true"]')
+  if (!active) return
+  // Solo ajusta el scroll horizontal del contenedor; no toca el scroll de la página.
+  const target = active.offsetLeft - (el.clientWidth - active.clientWidth) / 2
+  el.scrollLeft = Math.max(0, target)
+}
+
+let resizeObserver = null
+
+onMounted(() => {
+  nextTick(() => {
+    scrollActiveIntoView()
+    updateScrollState()
+  })
+  if (typeof ResizeObserver !== 'undefined' && scrollerRef.value) {
+    resizeObserver = new ResizeObserver(() => updateScrollState())
+    resizeObserver.observe(scrollerRef.value)
+  }
+})
+
+onBeforeUnmount(() => {
+  if (resizeObserver) resizeObserver.disconnect()
+})
+
+watch(() => route.path, () => {
+  nextTick(() => {
+    scrollActiveIntoView()
+    updateScrollState()
+  })
+})
 </script>

--- a/frontend/components/platform/projects/ProjectSecondarySidebar.vue
+++ b/frontend/components/platform/projects/ProjectSecondarySidebar.vue
@@ -1,44 +1,32 @@
 <template>
   <aside class="w-full shrink-0 self-start rounded-3xl border border-border-default bg-surface px-3 py-3 shadow-sm lg:w-56 lg:py-4">
-    <div class="relative">
-      <!-- Edge fades (móvil): insinúan que hay más tabs ocultos -->
-      <div
-        v-show="showLeftFade"
-        class="pointer-events-none absolute inset-y-0 left-0 z-10 w-8 bg-gradient-to-r from-surface to-transparent lg:hidden"
-      ></div>
-      <div
-        v-show="showRightFade"
-        class="pointer-events-none absolute inset-y-0 right-0 z-10 w-8 bg-gradient-to-l from-surface to-transparent lg:hidden"
-      ></div>
-
-      <div
-        ref="scrollerRef"
-        class="flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible"
-        @scroll="updateScrollState"
-      >
-        <template v-for="item in items" :key="item.disabled ? item.label : item.href">
-          <span
-            v-if="item.disabled"
-            class="flex shrink-0 cursor-not-allowed items-center justify-between gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium opacity-40"
-          >
-            {{ item.label }}
-            <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
-          </span>
-          <NuxtLink
-            v-else
-            :to="item.href"
-            :data-active="isActive(item.href)"
-            :class="[
-              'flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium transition',
-              isActive(item.href)
-                ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
-                : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
-            ]"
-          >
-            {{ item.label }}
-          </NuxtLink>
-        </template>
-      </div>
+    <div
+      ref="scrollerRef"
+      class="scrollbar-hide flex gap-1 overflow-x-auto lg:flex-col lg:overflow-visible"
+      @scroll="updateScrollState"
+    >
+      <template v-for="item in items" :key="item.disabled ? item.label : item.href">
+        <span
+          v-if="item.disabled"
+          class="flex shrink-0 cursor-not-allowed items-center justify-between gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium opacity-40"
+        >
+          {{ item.label }}
+          <span class="rounded-full bg-surface-muted px-1.5 py-0.5 text-[9px] font-semibold uppercase tracking-wide text-text-muted">Pronto</span>
+        </span>
+        <NuxtLink
+          v-else
+          :to="item.href"
+          :data-active="isActive(item.href)"
+          :class="[
+            'flex shrink-0 items-center gap-2 whitespace-nowrap rounded-xl px-3 py-2 text-sm font-medium transition',
+            isActive(item.href)
+              ? 'bg-primary-soft text-text-brand dark:bg-lemon/10 dark:text-accent'
+              : 'text-green-light hover:bg-primary-soft hover:text-text-brand dark:hover:text-accent',
+          ]"
+        >
+          {{ item.label }}
+        </NuxtLink>
+      </template>
     </div>
 
     <!-- Barrita indicadora de scroll (solo móvil, solo si hay overflow) -->
@@ -85,8 +73,6 @@ function isActive(href) {
 // --- Indicadores de scroll horizontal (móvil) ---
 const scrollerRef = ref(null)
 const hasOverflow = ref(false)
-const showLeftFade = ref(false)
-const showRightFade = ref(false)
 const thumbWidthPct = ref(100)
 const thumbLeftPct = ref(0)
 
@@ -101,8 +87,6 @@ function updateScrollState() {
   const { scrollLeft, scrollWidth, clientWidth } = el
   const max = scrollWidth - clientWidth
   hasOverflow.value = max > 2
-  showLeftFade.value = scrollLeft > 2
-  showRightFade.value = scrollLeft < max - 2
   thumbWidthPct.value = scrollWidth > 0 ? Math.min(100, (clientWidth / scrollWidth) * 100) : 100
   thumbLeftPct.value = scrollWidth > 0 ? (scrollLeft / scrollWidth) * 100 : 0
 }
@@ -141,3 +125,9 @@ watch(() => route.path, () => {
   })
 })
 </script>
+
+<style scoped>
+/* Oculta la scrollbar nativa: dejamos solo la barrita indicadora propia. */
+.scrollbar-hide::-webkit-scrollbar { display: none; }
+.scrollbar-hide { -ms-overflow-style: none; scrollbar-width: none; }
+</style>

--- a/frontend/components/platform/projects/ProjectShell.vue
+++ b/frontend/components/platform/projects/ProjectShell.vue
@@ -12,9 +12,9 @@
         <template v-if="project.next_deliverable"> · Próx. entrega: {{ formatDate(project.next_deliverable.due_date) }}</template>
       </p>
     </header>
-    <div class="flex gap-4">
+    <div class="flex flex-col gap-4 lg:flex-row">
       <ProjectSecondarySidebar :project-id="projectId" />
-      <main class="flex-1 rounded-3xl border border-border-default bg-surface px-6 py-6 shadow-sm">
+      <main class="min-w-0 flex-1 rounded-3xl border border-border-default bg-surface px-4 py-6 shadow-sm sm:px-6">
         <slot />
       </main>
     </div>

--- a/frontend/components/platform/projects/ProjectsTable.vue
+++ b/frontend/components/platform/projects/ProjectsTable.vue
@@ -1,5 +1,7 @@
 <template>
-  <div class="overflow-hidden rounded-2xl border border-border-default bg-surface">
+  <div>
+    <!-- Desktop / tablet: tabla con scroll horizontal como red de seguridad (>=md) -->
+    <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block">
     <table class="min-w-full text-left text-sm">
       <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
         <tr>
@@ -62,6 +64,66 @@
         </tr>
       </tbody>
     </table>
+    </div>
+
+    <!-- Móvil (<md): cada proyecto como tarjeta apilada -->
+    <div class="space-y-3 md:hidden">
+      <button
+        v-for="p in projects"
+        :key="p.id"
+        type="button"
+        :data-testid="`project-card-${p.id}`"
+        class="block w-full rounded-2xl border border-border-default bg-surface p-4 text-left transition hover:bg-primary-soft"
+        @click="$emit('navigate', p.id)"
+      >
+        <div class="flex items-start justify-between gap-3">
+          <div class="min-w-0">
+            <div class="truncate font-medium text-text-default">{{ p.name }}</div>
+            <span :class="statusChipClass(p.status)">{{ statusLabel(p.status) }}</span>
+          </div>
+          <span class="shrink-0 text-green-light/40">›</span>
+        </div>
+
+        <div v-if="isAdmin" class="mt-3 text-sm text-green-light">
+          {{ p.client_name }}
+          <span class="block truncate text-xs text-green-light/60">{{ p.client_email }}</span>
+        </div>
+
+        <div class="mt-3 flex items-center gap-2">
+          <div class="h-1.5 w-full max-w-[8rem] overflow-hidden rounded-full bg-surface-muted">
+            <div class="h-full bg-primary" :style="{ width: `${p.progress || 0}%` }"></div>
+          </div>
+          <span class="text-xs text-green-light/70">{{ p.progress || 0 }}%</span>
+        </div>
+
+        <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-sm">
+          <div class="flex items-center justify-between gap-2">
+            <dt class="text-xs uppercase tracking-wide text-green-light/60">Bugs</dt>
+            <dd>
+              <span :class="(p.bugs_open_count || 0) > 0 ? 'rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700' : 'text-green-light/60'">{{ p.bugs_open_count || 0 }}</span>
+            </dd>
+          </div>
+          <div v-if="isAdmin" class="flex items-center justify-between gap-2">
+            <dt class="text-xs uppercase tracking-wide text-green-light/60">Solicitudes</dt>
+            <dd>
+              <span :class="(p.changes_pending_count || 0) > 0 ? 'rounded-full bg-amber-100 px-2 py-0.5 text-xs font-medium text-amber-700' : 'text-green-light/60'">{{ p.changes_pending_count || 0 }}</span>
+            </dd>
+          </div>
+          <div class="flex items-center justify-between gap-2">
+            <dt class="text-xs uppercase tracking-wide text-green-light/60">Valor</dt>
+            <dd :class="(Number(p.phases_total_amount) > 0) ? 'font-medium text-text-default' : 'text-green-light/60'">{{ formatCurrency(p.phases_total_amount) }}</dd>
+          </div>
+          <div class="flex items-center justify-between gap-2">
+            <dt class="text-xs uppercase tracking-wide text-green-light/60">Actividad</dt>
+            <dd class="text-green-light/70">{{ relativeTime(p.last_activity_at) }}</dd>
+          </div>
+        </dl>
+      </button>
+
+      <div v-if="!projects.length" class="rounded-2xl border border-border-default bg-surface px-4 py-12 text-center text-green-light/60">
+        No hay proyectos para mostrar.
+      </div>
+    </div>
   </div>
 </template>
 

--- a/frontend/components/platform/projects/ProjectsTable.vue
+++ b/frontend/components/platform/projects/ProjectsTable.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
-    <!-- Desktop / tablet: tabla con scroll horizontal como red de seguridad (>=md) -->
-    <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block">
+    <!-- Desktop / tablet (>=md): tabla con scroll horizontal como red de seguridad -->
+    <div v-if="!isMobile" class="overflow-x-auto rounded-2xl border border-border-default bg-surface">
     <table class="min-w-full text-left text-sm">
       <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
         <tr>
@@ -67,7 +67,7 @@
     </div>
 
     <!-- Móvil (<md): cada proyecto como tarjeta apilada -->
-    <div class="space-y-3 md:hidden">
+    <div v-else class="space-y-3">
       <button
         v-for="p in projects"
         :key="p.id"
@@ -129,6 +129,7 @@
 
 <script setup>
 import { computed } from 'vue'
+import { useIsMobile } from '~/composables/useIsMobile'
 
 const props = defineProps({
   projects: { type: Array, required: true },
@@ -136,6 +137,8 @@ const props = defineProps({
 })
 
 defineEmits(['navigate'])
+
+const { isMobile } = useIsMobile()
 
 const isAdmin = computed(() => props.role === 'admin')
 

--- a/frontend/composables/useIsMobile.js
+++ b/frontend/composables/useIsMobile.js
@@ -1,0 +1,31 @@
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+
+/**
+ * Breakpoint móvil reactivo.
+ *
+ * Arranca en `false` (desktop-first) en SSR / primer render y se corrige en el
+ * cliente al montar. Sirve para alternar entre tabla (desktop) y tarjetas
+ * (móvil) con `v-if`/`v-else`, de modo que SOLO una de las dos exista en el DOM.
+ *
+ * Por qué v-if y no `hidden md:block` / `md:hidden`: con el toggle por CSS ambas
+ * versiones quedan en el DOM (una con `display:none`), lo que duplica el texto y
+ * rompe los `getByText(...)` en modo estricto de los E2E.
+ */
+export function useIsMobile(maxWidth = 767) {
+  const isMobile = ref(false)
+  let mql = null
+  const update = () => { isMobile.value = !!mql && mql.matches }
+
+  onMounted(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return
+    mql = window.matchMedia(`(max-width: ${maxWidth}px)`)
+    update()
+    mql.addEventListener('change', update)
+  })
+
+  onBeforeUnmount(() => {
+    if (mql) mql.removeEventListener('change', update)
+  })
+
+  return { isMobile }
+}

--- a/frontend/composables/usePlatformNav.js
+++ b/frontend/composables/usePlatformNav.js
@@ -1,0 +1,47 @@
+import { computed } from 'vue'
+import { usePlatformAuthStore } from '~/stores/platform-auth'
+import { usePlatformNotificationsStore } from '~/stores/platform-notifications'
+
+/**
+ * Fuente única de la navegación de la plataforma.
+ *
+ * El sidebar de desktop (`PlatformSidebar.vue`) y el drawer móvil
+ * (`PlatformMobileDrawer.vue`) consumen estos mismos items para que ambas
+ * superficies no vuelvan a desincronizarse, como pasó tras el refactor de IA
+ * (los módulos globales Tablero/Solicitudes/Bugs/etc. ahora viven dentro de
+ * cada proyecto y las rutas globales quedaron como redirects).
+ */
+export function usePlatformNav() {
+  const localePath = useLocalePath()
+  const route = useRoute()
+  const authStore = usePlatformAuthStore()
+  const notifStore = usePlatformNotificationsStore()
+  const lp = (path) => localePath(path)
+
+  const primaryItems = computed(() => {
+    const items = [
+      { label: 'Notificaciones', href: lp('/platform/notifications'), icon: 'bell', badge: notifStore.unreadCount },
+      { label: 'Proyectos',      href: lp('/platform/projects'),      icon: 'folder' },
+    ]
+    if (authStore.isAdmin) {
+      items.push({ label: 'Clientes', href: lp('/platform/clients'), icon: 'users' })
+    }
+    return items
+  })
+
+  const accountItems = computed(() => [
+    { label: 'Configuración', href: lp('/platform/profile'), icon: 'settings' },
+  ])
+
+  const adminItems = computed(() => [
+    { label: 'Panel admin', href: '/panel', icon: 'external', external: true },
+  ])
+
+  function isActive(href) {
+    const cleanPath = route.path.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
+    const cleanHref = href.replace(/^\/[a-z]{2}-[a-z]{2}/, '')
+    return cleanPath === cleanHref || cleanPath.startsWith(`${cleanHref}/`)
+  }
+
+  return { primaryItems, accountItems, adminItems, isActive }
+}

--- a/frontend/e2e/admin/admin-proposal-dashboard-auto-refresh.spec.js
+++ b/frontend/e2e/admin/admin-proposal-dashboard-auto-refresh.spec.js
@@ -85,8 +85,10 @@ test.describe('Admin Proposal Dashboard Auto-Refresh', () => {
     // Click refresh
     await page.getByRole('button', { name: 'Actualizar', exact: true }).click();
 
-    // Updated data should appear
-    await expect(page.getByText('15')).toBeVisible({ timeout: 5000 });
+    // Updated data should appear. Use exact match: a non-exact '15' also
+    // matches the "151d sin actividad" inactivity badge in the proposals
+    // table (date-dependent), which caused a strict-mode violation.
+    await expect(page.getByText('15', { exact: true })).toBeVisible({ timeout: 5000 });
     await expect(page.getByText('50%')).toBeVisible();
     expect(dashboardCalls).toBeGreaterThan(1);
   });

--- a/frontend/layouts/platform.vue
+++ b/frontend/layouts/platform.vue
@@ -40,7 +40,7 @@
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 6h16M4 12h16M4 18h16" />
         </svg>
       </button>
-      <NuxtLink :to="localePath('/platform/dashboard')" class="text-base font-bold tracking-tight text-text-brand dark:text-white">
+      <NuxtLink :to="localePath('/platform/projects')" class="text-base font-bold tracking-tight text-text-brand dark:text-white">
         Project<span class="text-green-light dark:text-accent">App.</span>
       </NuxtLink>
       <div class="h-8 w-8 shrink-0 overflow-hidden rounded-full">

--- a/frontend/pages/platform/clients/[id].vue
+++ b/frontend/pages/platform/clients/[id].vue
@@ -19,7 +19,7 @@
       No encontramos el cliente solicitado.
     </div>
 
-    <div v-else class="grid gap-6 xl:grid-cols-[0.85fr_1.15fr]">
+    <div v-else class="grid grid-cols-1 gap-6 xl:grid-cols-[0.85fr_1.15fr]">
       <section class="space-y-6" data-enter>
         <article class="rounded-3xl border border-border-default bg-surface p-6 shadow-sm">
           <div class="flex items-center gap-4">
@@ -34,9 +34,9 @@
                 {{ clientInitials }}
               </div>
             </div>
-            <div>
-              <h2 class="text-lg font-medium text-text-default">{{ form.first_name }} {{ form.last_name }}</h2>
-              <p class="mt-0.5 text-sm text-green-light">{{ platformClientsStore.currentClient.email }}</p>
+            <div class="min-w-0">
+              <h2 class="truncate text-lg font-medium text-text-default">{{ form.first_name }} {{ form.last_name }}</h2>
+              <p class="mt-0.5 truncate text-sm text-green-light">{{ platformClientsStore.currentClient.email }}</p>
             </div>
           </div>
 

--- a/frontend/pages/platform/clients/index.vue
+++ b/frontend/pages/platform/clients/index.vue
@@ -54,6 +54,61 @@
         {{ search.trim() ? 'No encontramos clientes con ese criterio.' : 'Todavía no hay clientes en esta vista.' }}
       </div>
 
+      <!-- Móvil: lista de filas-tarjeta -->
+      <div v-else-if="isMobile" class="divide-y divide-border-muted">
+        <button
+          v-for="client in filteredClients"
+          :key="client.user_id"
+          type="button"
+          class="flex w-full items-start gap-3 p-4 text-left transition hover:bg-primary-soft"
+          @click="goToClient(client.user_id)"
+        >
+          <div class="h-9 w-9 shrink-0 overflow-hidden rounded-full">
+            <img v-if="client.avatar_display_url" :src="client.avatar_display_url" alt="Avatar" class="h-full w-full object-cover" />
+            <div v-else class="flex h-full w-full items-center justify-center bg-surface-muted text-xs font-semibold text-text-default dark:bg-white/10 dark:text-white">
+              {{ initials(client) }}
+            </div>
+          </div>
+          <div class="min-w-0 flex-1">
+            <div class="flex items-center gap-2">
+              <p class="truncate font-medium text-text-default">{{ client.first_name }} {{ client.last_name }}</p>
+              <span v-if="!client.is_active" class="shrink-0 rounded-full bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-600 dark:bg-white/10 dark:text-green-light/70">Inactivo</span>
+            </div>
+            <p class="truncate text-xs text-green-light/60">{{ client.email }}</p>
+            <dl class="mt-3 grid grid-cols-2 gap-x-4 gap-y-2 text-xs">
+              <div>
+                <dt class="text-green-light/50">Empresa</dt>
+                <dd class="truncate text-green-light">{{ client.company_name || '—' }}</dd>
+              </div>
+              <div>
+                <dt class="text-green-light/50">Proyectos</dt>
+                <dd class="text-green-light">{{ client.active_projects_count ?? 0 }} / {{ client.total_projects_count ?? 0 }}</dd>
+              </div>
+              <div>
+                <dt class="text-green-light/50">Plan hosting</dt>
+                <dd>
+                  <span v-if="client.hosting_plan" class="rounded-full bg-primary-soft px-2 py-0.5 text-[10px] font-medium text-text-brand dark:bg-lemon/10 dark:text-accent">{{ planLabel(client.hosting_plan) }}</span>
+                  <span v-else class="text-green-light/60">—</span>
+                </dd>
+              </div>
+              <div>
+                <dt class="text-green-light/50">Próx. renovación</dt>
+                <dd :class="renewalClass(client.hosting_renewal_at)">{{ formatDate(client.hosting_renewal_at) }}</dd>
+              </div>
+              <div>
+                <dt class="text-green-light/50">Valor renovación</dt>
+                <dd class="text-green-light">{{ formatMoney(client.hosting_renewal_value) }}</dd>
+              </div>
+              <div>
+                <dt class="text-green-light/50">Última actividad</dt>
+                <dd class="text-green-light/70">{{ relativeTime(client.last_activity_at) }}</dd>
+              </div>
+            </dl>
+          </div>
+          <span class="shrink-0 self-center text-green-light/40">›</span>
+        </button>
+      </div>
+
       <div v-else class="overflow-x-auto">
         <table class="min-w-full text-left text-sm">
           <thead>
@@ -202,6 +257,7 @@
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import ConfirmModal from '~/components/ConfirmModal.vue'
 import { useConfirmModal } from '~/composables/useConfirmModal'
+import { useIsMobile } from '~/composables/useIsMobile'
 
 const localePath = useLocalePath()
 import { usePageEntrance } from '~/composables/usePageEntrance'
@@ -216,6 +272,7 @@ definePageMeta({
 usePageEntrance('#platform-clients')
 
 const platformClientsStore = usePlatformClientsStore()
+const { isMobile } = useIsMobile()
 const activeFilter = ref('active')
 const search = ref('')
 const isInviteModalOpen = ref(false)

--- a/frontend/pages/platform/projects/[id]/bugs.vue
+++ b/frontend/pages/platform/projects/[id]/bugs.vue
@@ -90,7 +90,7 @@
 
       <!-- Table -->
       <template v-if="filteredBugs.length">
-      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
+      <div v-if="!isMobile" class="overflow-x-auto rounded-2xl border border-border-default bg-surface" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -164,7 +164,7 @@
       </div>
 
       <!-- Cards (mobile) -->
-      <div class="space-y-3 md:hidden" data-enter>
+      <div v-else class="space-y-3" data-enter>
         <button
           v-for="bug in filteredBugs"
           :key="bug.id"
@@ -590,6 +590,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { usePageEntrance } from '~/composables/usePageEntrance'
+import { useIsMobile } from '~/composables/useIsMobile'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
 import { usePlatformBugReportsStore } from '~/stores/platform-bug-reports'
 import { usePlatformProjectsStore } from '~/stores/platform-projects'
@@ -605,6 +606,8 @@ const authStore = usePlatformAuthStore()
 const bugStore = usePlatformBugReportsStore()
 const projectsStore = usePlatformProjectsStore()
 const requirementsStore = usePlatformRequirementsStore()
+
+const { isMobile } = useIsMobile()
 
 const projectRequirements = ref([])
 

--- a/frontend/pages/platform/projects/[id]/bugs.vue
+++ b/frontend/pages/platform/projects/[id]/bugs.vue
@@ -89,7 +89,8 @@
       </div>
 
       <!-- Table -->
-      <div v-if="filteredBugs.length" class="overflow-hidden rounded-2xl border border-border-default bg-surface" data-enter>
+      <template v-if="filteredBugs.length">
+      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -161,6 +162,41 @@
           </tbody>
         </table>
       </div>
+
+      <!-- Cards (mobile) -->
+      <div class="space-y-3 md:hidden" data-enter>
+        <button
+          v-for="bug in filteredBugs"
+          :key="bug.id"
+          type="button"
+          class="block w-full rounded-2xl border border-border-default bg-surface p-4 text-left transition hover:bg-primary-soft"
+          :class="bug.is_archived ? 'opacity-70' : ''"
+          @click="openDetailModal(bug)"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <p class="font-medium text-text-default">{{ bug.title }}</p>
+                <span v-if="bug.is_recurring" class="rounded-full bg-purple-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase text-purple-600 dark:text-purple-400">Recurrente</span>
+                <span v-if="bug.is_archived" class="rounded-full bg-gray-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-text-muted dark:text-text-subtle">Archivado</span>
+                <svg v-if="bug.screenshot_url" class="h-3 w-3 shrink-0 text-green-light/40" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z" /></svg>
+              </div>
+              <p v-if="bug.source_requirement" class="mt-0.5 line-clamp-1 text-[10px] text-teal-600 dark:text-teal-300">Sobre: {{ bug.source_requirement.title }}</p>
+            </div>
+            <span class="shrink-0 text-green-light/40">›</span>
+          </div>
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase" :class="statusBadgeClass(bug.status)">{{ statusLabel(bug.status) }}</span>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase" :class="severityBadgeClass(bug.severity)">{{ severityLabel(bug.severity) }}</span>
+            <span class="text-[10px] text-green-light/60">{{ envLabel(bug.environment) }}</span>
+          </div>
+          <div class="mt-2 flex items-center justify-between gap-2 text-xs text-green-light/70">
+            <span class="truncate">{{ bug.reported_by_name }}</span>
+            <span class="shrink-0">{{ formatDate(bug.created_at) }}</span>
+          </div>
+        </button>
+      </div>
+      </template>
 
       <!-- Empty -->
       <div v-else class="py-16 text-center" data-enter>

--- a/frontend/pages/platform/projects/[id]/changes.vue
+++ b/frontend/pages/platform/projects/[id]/changes.vue
@@ -92,7 +92,7 @@
 
       <!-- Table (md+) / Cards (mobile) -->
       <template v-if="filteredRequests.length">
-      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
+      <div v-if="!isMobile" class="overflow-x-auto rounded-2xl border border-border-default bg-surface" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -165,7 +165,7 @@
       </div>
 
       <!-- Cards (mobile) -->
-      <div class="space-y-3 md:hidden" data-enter>
+      <div v-else class="space-y-3" data-enter>
         <button
           v-for="cr in filteredRequests"
           :key="cr.id"
@@ -582,6 +582,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { usePageEntrance } from '~/composables/usePageEntrance'
+import { useIsMobile } from '~/composables/useIsMobile'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
 import { usePlatformChangeRequestsStore } from '~/stores/platform-change-requests'
 import { usePlatformProjectsStore } from '~/stores/platform-projects'
@@ -601,6 +602,8 @@ const authStore = usePlatformAuthStore()
 const crStore = usePlatformChangeRequestsStore()
 const projectsStore = usePlatformProjectsStore()
 const requirementsStore = usePlatformRequirementsStore()
+
+const { isMobile } = useIsMobile()
 
 const projectRequirements = ref([])
 

--- a/frontend/pages/platform/projects/[id]/changes.vue
+++ b/frontend/pages/platform/projects/[id]/changes.vue
@@ -90,8 +90,9 @@
         </button>
       </div>
 
-      <!-- Table -->
-      <div v-if="filteredRequests.length" class="overflow-hidden rounded-2xl border border-border-default bg-surface" data-enter>
+      <!-- Table (md+) / Cards (mobile) -->
+      <template v-if="filteredRequests.length">
+      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -162,6 +163,41 @@
           </tbody>
         </table>
       </div>
+
+      <!-- Cards (mobile) -->
+      <div class="space-y-3 md:hidden" data-enter>
+        <button
+          v-for="cr in filteredRequests"
+          :key="cr.id"
+          type="button"
+          class="block w-full rounded-2xl border border-border-default bg-surface p-4 text-left transition hover:bg-primary-soft"
+          :class="cr.is_archived ? 'opacity-70' : ''"
+          @click="openDetailModal(cr)"
+        >
+          <div class="flex items-start justify-between gap-2">
+            <div class="min-w-0 flex-1">
+              <div class="flex flex-wrap items-center gap-1.5">
+                <p class="font-medium text-text-default">{{ cr.title }}</p>
+                <span v-if="cr.is_urgent" class="rounded-full bg-red-500/15 px-1.5 py-0.5 text-[9px] font-bold uppercase text-red-600 dark:text-red-400">Urgente</span>
+                <span v-if="cr.is_archived" class="rounded-full bg-gray-500/15 px-1.5 py-0.5 text-[9px] font-semibold uppercase text-text-muted dark:text-text-subtle">Archivada</span>
+                <span v-if="cr.linked_requirement_id" class="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-semibold text-text-brand">Convertida</span>
+              </div>
+              <p v-if="cr.source_requirement" class="mt-0.5 line-clamp-1 text-[10px] text-teal-600 dark:text-teal-300">Sobre: {{ cr.source_requirement.title }}</p>
+              <p v-else-if="cr.module_or_screen" class="mt-0.5 line-clamp-1 text-[10px] text-green-light/60">{{ cr.module_or_screen }}</p>
+            </div>
+            <span class="shrink-0 text-green-light/40">›</span>
+          </div>
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase" :class="statusBadgeClass(cr.status)">{{ statusLabel(cr.status) }}</span>
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase" :class="priorityBadgeClass(cr.suggested_priority)">{{ priorityLabel(cr.suggested_priority) }}</span>
+          </div>
+          <div class="mt-2 flex items-center justify-between gap-2 text-xs text-green-light/70">
+            <span class="truncate">{{ cr.created_by_name }}</span>
+            <span class="shrink-0">{{ formatDate(cr.created_at) }}</span>
+          </div>
+        </button>
+      </div>
+      </template>
 
       <!-- Empty state -->
       <div v-else class="py-16 text-center" data-enter>

--- a/frontend/pages/platform/projects/[id]/deliverables/index.vue
+++ b/frontend/pages/platform/projects/[id]/deliverables/index.vue
@@ -46,7 +46,8 @@
       </div>
 
       <!-- Table -->
-      <div v-if="filteredItems.length" class="overflow-hidden rounded-2xl border border-border-default bg-surface" data-enter>
+      <template v-if="filteredItems.length">
+      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -95,6 +96,39 @@
           </tbody>
         </table>
       </div>
+
+      <!-- Cards (mobile) -->
+      <div class="space-y-3 md:hidden" data-enter>
+        <button
+          v-for="d in filteredItems"
+          :key="d.id"
+          type="button"
+          class="block w-full rounded-2xl border border-border-default bg-surface p-4 text-left transition hover:bg-primary-soft"
+          :class="d.is_archived ? 'opacity-70' : ''"
+          @click="openDetailModal(d)"
+        >
+          <div class="flex items-center gap-3">
+            <span class="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl" :class="categoryIconBg(d.category)">
+              <span class="text-base">{{ categoryIcon(d.category) }}</span>
+            </span>
+            <div class="min-w-0 flex-1">
+              <p class="truncate font-medium text-text-default">{{ d.title }}</p>
+              <p class="truncate text-[11px] text-green-light/60">{{ d.file_name || '—' }}</p>
+            </div>
+            <span class="shrink-0 text-green-light/40">›</span>
+          </div>
+          <div class="mt-3 flex flex-wrap items-center gap-2">
+            <span class="rounded-full px-2 py-0.5 text-[10px] font-semibold uppercase" :class="categoryBadgeClass(d.category)">{{ categoryLabel(d.category) }}</span>
+            <span v-if="d.is_archived" class="rounded-full bg-gray-500/15 px-2 py-0.5 text-[10px] font-semibold uppercase text-text-muted dark:text-text-subtle">Archivado</span>
+            <span class="text-[10px] text-green-light/60">{{ formatBytes(d.file_size) }} · v{{ d.current_version }}</span>
+          </div>
+          <div class="mt-2 flex items-center justify-between gap-2 text-xs text-green-light/70">
+            <span class="truncate">{{ d.uploaded_by_name }}</span>
+            <span class="shrink-0">{{ formatDate(d.updated_at) }}</span>
+          </div>
+        </button>
+      </div>
+      </template>
 
       <!-- Empty -->
       <div v-else class="py-16 text-center" data-enter>

--- a/frontend/pages/platform/projects/[id]/deliverables/index.vue
+++ b/frontend/pages/platform/projects/[id]/deliverables/index.vue
@@ -47,7 +47,7 @@
 
       <!-- Table -->
       <template v-if="filteredItems.length">
-      <div class="hidden overflow-x-auto rounded-2xl border border-border-default bg-surface md:block" data-enter>
+      <div v-if="!isMobile" class="overflow-x-auto rounded-2xl border border-border-default bg-surface" data-enter>
         <table class="min-w-full text-left text-sm">
           <thead class="bg-surface-muted/40 text-xs font-medium uppercase tracking-wider text-green-light/70">
             <tr>
@@ -98,7 +98,7 @@
       </div>
 
       <!-- Cards (mobile) -->
-      <div class="space-y-3 md:hidden" data-enter>
+      <div v-else class="space-y-3" data-enter>
         <button
           v-for="d in filteredItems"
           :key="d.id"
@@ -353,6 +353,7 @@
 <script setup>
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { usePageEntrance } from '~/composables/usePageEntrance'
+import { useIsMobile } from '~/composables/useIsMobile'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
 import { usePlatformDeliverablesStore } from '~/stores/platform-deliverables'
 import { usePlatformProjectsStore } from '~/stores/platform-projects'
@@ -366,6 +367,8 @@ const localePath = useLocalePath()
 const authStore = usePlatformAuthStore()
 const store = usePlatformDeliverablesStore()
 const projectsStore = usePlatformProjectsStore()
+
+const { isMobile } = useIsMobile()
 
 const projectId = computed(() => route.params.id)
 const projectName = computed(() => projectsStore.currentProject?.name || 'Proyecto')

--- a/frontend/pages/platform/projects/index.vue
+++ b/frontend/pages/platform/projects/index.vue
@@ -141,19 +141,59 @@
 
                 <div>
                   <label class="mb-1.5 block text-xs font-medium text-esmerald/70 dark:text-white/70">Propuesta de negocio</label>
-                  <select
-                    v-model="createForm.proposal_id"
-                    class="w-full rounded-xl border border-border-default bg-surface-muted/40 px-4 py-3 text-sm text-text-default outline-none transition focus:border-border-default dark:bg-primary-strong dark:text-white dark:focus:border-lemon/40"
-                  >
-                    <option :value="null">Sin propuesta vinculada</option>
-                    <option
-                      v-for="p in paymentsStore.proposals"
-                      :key="p.id"
-                      :value="p.id"
+                  <div ref="proposalSelectRef" class="relative">
+                    <button
+                      type="button"
+                      class="flex w-full items-center justify-between gap-2 rounded-xl border border-border-default bg-surface-muted/40 px-4 py-3 text-left text-sm outline-none transition focus:border-border-default dark:bg-primary-strong dark:focus:border-lemon/40"
+                      @click="toggleProposalDropdown"
                     >
-                      {{ p.title }} — {{ formatCurrency(p.total_investment, p.currency) }}
-                    </option>
-                  </select>
+                      <span class="truncate" :class="createForm.proposal_id ? 'text-text-default' : 'text-green-light/60'">
+                        {{ selectedProposalLabel || 'Sin propuesta vinculada' }}
+                      </span>
+                      <svg class="h-4 w-4 shrink-0 text-green-light/50 transition-transform" :class="proposalDropdownOpen ? 'rotate-180' : ''" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" /></svg>
+                    </button>
+                    <div
+                      v-if="proposalDropdownOpen"
+                      class="absolute z-20 mt-1 w-full overflow-hidden rounded-xl border border-border-default bg-surface shadow-lg"
+                    >
+                      <div class="border-b border-border-muted p-2">
+                        <input
+                          ref="proposalSearchInput"
+                          v-model="proposalSearch"
+                          type="text"
+                          placeholder="Buscar propuesta por nombre..."
+                          class="w-full rounded-lg border border-border-default bg-surface-muted/40 px-3 py-2 text-sm text-text-default outline-none transition placeholder:text-green-light/50 focus:border-border-default dark:bg-primary-strong dark:text-white dark:placeholder:text-white/30 dark:focus:border-lemon/40"
+                          @keydown.esc.stop.prevent="closeProposalDropdown"
+                        />
+                      </div>
+                      <ul class="max-h-56 overflow-y-auto py-1">
+                        <li>
+                          <button
+                            type="button"
+                            class="w-full px-3 py-2 text-left text-sm transition hover:bg-primary-soft dark:hover:bg-white/5"
+                            :class="!createForm.proposal_id ? 'text-text-brand dark:text-accent' : 'text-green-light'"
+                            @click="selectProposal(null)"
+                          >
+                            Sin propuesta vinculada
+                          </button>
+                        </li>
+                        <li v-for="p in filteredProposals" :key="p.id">
+                          <button
+                            type="button"
+                            class="flex w-full items-center justify-between gap-2 px-3 py-2 text-left text-sm transition hover:bg-primary-soft dark:hover:bg-white/5"
+                            :class="createForm.proposal_id === p.id ? 'bg-primary-soft dark:bg-white/5' : ''"
+                            @click="selectProposal(p)"
+                          >
+                            <span class="truncate text-text-default">{{ p.title }}</span>
+                            <span class="shrink-0 text-xs text-green-light/60">{{ formatCurrency(p.total_investment, p.currency) }}</span>
+                          </button>
+                        </li>
+                        <li v-if="!filteredProposals.length" class="px-3 py-4 text-center text-xs text-green-light/60">
+                          No hay propuestas que coincidan.
+                        </li>
+                      </ul>
+                    </div>
+                  </div>
                   <p class="mt-1 text-[11px] text-green-light/60">
                     Al vincular una propuesta, se crean automáticamente los requerimientos del tablero Kanban.
                   </p>
@@ -214,7 +254,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, nextTick, onBeforeUnmount, onMounted, reactive, ref } from 'vue'
 import { usePageEntrance } from '~/composables/usePageEntrance'
 import { usePlatformAuthStore } from '~/stores/platform-auth'
 import { usePlatformProjectsStore } from '~/stores/platform-projects'
@@ -265,6 +305,51 @@ const clientsForSelect = computed(() =>
   clientsStore.clients.filter((c) => c.is_active && c.is_onboarded),
 )
 
+// --- Selector de propuesta con buscador ---
+const proposalSearch = ref('')
+const proposalDropdownOpen = ref(false)
+const proposalSelectRef = ref(null)
+const proposalSearchInput = ref(null)
+
+const filteredProposals = computed(() => {
+  const list = paymentsStore.proposals || []
+  const q = proposalSearch.value.trim().toLowerCase()
+  if (!q) return list
+  return list.filter((p) => (p.title || '').toLowerCase().includes(q))
+})
+
+const selectedProposalLabel = computed(() => {
+  if (!createForm.proposal_id) return ''
+  const p = (paymentsStore.proposals || []).find((x) => x.id === createForm.proposal_id)
+  return p ? `${p.title} — ${formatCurrency(p.total_investment, p.currency)}` : ''
+})
+
+function toggleProposalDropdown() {
+  proposalDropdownOpen.value = !proposalDropdownOpen.value
+  if (proposalDropdownOpen.value) {
+    proposalSearch.value = ''
+    nextTick(() => proposalSearchInput.value?.focus())
+  }
+}
+
+function closeProposalDropdown() {
+  proposalDropdownOpen.value = false
+}
+
+function selectProposal(proposal) {
+  createForm.proposal_id = proposal ? proposal.id : null
+  closeProposalDropdown()
+}
+
+function onClickOutsideProposal(event) {
+  if (proposalSelectRef.value && !proposalSelectRef.value.contains(event.target)) {
+    closeProposalDropdown()
+  }
+}
+
+onMounted(() => document.addEventListener('mousedown', onClickOutsideProposal))
+onBeforeUnmount(() => document.removeEventListener('mousedown', onClickOutsideProposal))
+
 const canCreate = computed(() => Boolean(createForm.name.trim()) && Boolean(createForm.client_id))
 
 function statusBadgeClass(status) {
@@ -310,6 +395,8 @@ function formatCurrency(amount, currency) {
 function closeCreateModal() {
   isCreateModalOpen.value = false
   createError.value = ''
+  proposalDropdownOpen.value = false
+  proposalSearch.value = ''
   createForm.name = ''
   createForm.description = ''
   createForm.client_id = ''

--- a/frontend/test/components/platform-projects-table.test.js
+++ b/frontend/test/components/platform-projects-table.test.js
@@ -33,4 +33,12 @@ describe('ProjectsTable', () => {
     const w = mount(ProjectsTable, { props: { projects: rows, role: 'client' } })
     expect(w.text()).not.toContain('Ada Lovelace')
   })
+
+  it('renders a mobile card per project that emits navigate on click', async () => {
+    const w = mount(ProjectsTable, { props: { projects: rows, role: 'admin' } })
+    const card = w.find('[data-testid="project-card-1"]')
+    expect(card.exists()).toBe(true)
+    await card.trigger('click')
+    expect(w.emitted('navigate')[0]).toEqual([1])
+  })
 })

--- a/frontend/test/components/platform-projects-table.test.js
+++ b/frontend/test/components/platform-projects-table.test.js
@@ -2,8 +2,18 @@ import { mount } from '@vue/test-utils'
 import { setActivePinia, createPinia } from 'pinia'
 import ProjectsTable from '../../components/platform/projects/ProjectsTable.vue'
 
+// Fuerza el breakpoint móvil (useIsMobile usa window.matchMedia).
+function mockViewport({ mobile }) {
+  window.matchMedia = jest.fn().mockReturnValue({
+    matches: mobile,
+    addEventListener: jest.fn(),
+    removeEventListener: jest.fn(),
+  })
+}
+
 describe('ProjectsTable', () => {
   beforeEach(() => { setActivePinia(createPinia()) })
+  afterEach(() => { delete window.matchMedia })
 
   const rows = [
     {
@@ -35,7 +45,9 @@ describe('ProjectsTable', () => {
   })
 
   it('renders a mobile card per project that emits navigate on click', async () => {
+    mockViewport({ mobile: true })
     const w = mount(ProjectsTable, { props: { projects: rows, role: 'admin' } })
+    await w.vm.$nextTick()
     const card = w.find('[data-testid="project-card-1"]')
     expect(card.exists()).toBe(true)
     await card.trigger('click')

--- a/frontend/test/composables/usePlatformNav.test.js
+++ b/frontend/test/composables/usePlatformNav.test.js
@@ -1,0 +1,67 @@
+/**
+ * Tests for usePlatformNav — la fuente única de navegación de la plataforma.
+ *
+ * Protege contra la regresión que motivó este composable: el sidebar desktop
+ * y el drawer móvil tenían la nav duplicada y derivaron (el drawer seguía
+ * enlazando Dashboard y los módulos globales que el refactor de IA convirtió
+ * en redirects).
+ */
+
+global.useLocalePath = jest.fn(() => (path) => path)
+global.useRoute = jest.fn(() => ({ path: '/platform/projects' }))
+
+const mockAuth = { isAdmin: false }
+jest.mock('../../stores/platform-auth', () => ({
+  usePlatformAuthStore: jest.fn(() => mockAuth),
+}))
+jest.mock('../../stores/platform-notifications', () => ({
+  usePlatformNotificationsStore: jest.fn(() => ({ unreadCount: 5 })),
+}))
+
+import { usePlatformNav } from '../../composables/usePlatformNav'
+
+describe('usePlatformNav', () => {
+  beforeEach(() => {
+    mockAuth.isAdmin = false
+    global.useRoute = jest.fn(() => ({ path: '/platform/projects' }))
+  })
+
+  it('expone Notificaciones y Proyectos para cualquier rol', () => {
+    const { primaryItems } = usePlatformNav()
+    const labels = primaryItems.value.map((i) => i.label)
+    expect(labels).toContain('Notificaciones')
+    expect(labels).toContain('Proyectos')
+  })
+
+  it('oculta Clientes para el rol client y lo muestra para admin', () => {
+    let { primaryItems } = usePlatformNav()
+    expect(primaryItems.value.map((i) => i.label)).not.toContain('Clientes')
+
+    mockAuth.isAdmin = true
+    ;({ primaryItems } = usePlatformNav())
+    expect(primaryItems.value.map((i) => i.label)).toContain('Clientes')
+  })
+
+  it('no expone las rutas globales eliminadas por el refactor de IA', () => {
+    mockAuth.isAdmin = true
+    const { primaryItems, accountItems, adminItems } = usePlatformNav()
+    const hrefs = [...primaryItems.value, ...accountItems.value, ...adminItems.value].map((i) => i.href)
+    for (const dead of [
+      '/platform/dashboard',
+      '/platform/board',
+      '/platform/bugs',
+      '/platform/changes',
+      '/platform/deliverables',
+      '/platform/payments',
+    ]) {
+      expect(hrefs).not.toContain(dead)
+    }
+  })
+
+  it('isActive coincide en ruta exacta y anidada, ignorando el prefijo de locale', () => {
+    global.useRoute = jest.fn(() => ({ path: '/en-us/platform/projects/5/board' }))
+    const { isActive } = usePlatformNav()
+    expect(isActive('/en-us/platform/projects')).toBe(true)
+    expect(isActive('/en-us/platform/clients')).toBe(false)
+  })
+})


### PR DESCRIPTION
## Resumen

Se hicieron responsive las vistas de la plataforma que se rompían en móvil/tablet, tanto para admin como para cliente, y se alineó el sidebar móvil con el de desktop.

## Cambios

### Lista de proyectos (`/platform/projects`)
- La tabla (ancho ~946px) estaba en un contenedor `overflow-hidden` que recortaba columnas sin scroll. Ahora: **tarjetas en móvil** (`<md`) y tabla con `overflow-x-auto` en `md+`.

### Sidebar móvil ↔ desktop
- El drawer móvil tenía la navegación pre-refactor IA (enlazaba a Dashboard y a los módulos globales Tablero/Solicitudes/Bugs/etc. que hoy son redirects). Se extrajo la nav a un composable único (`usePlatformNav`) que consumen el sidebar desktop y el drawer móvil, para que no vuelvan a desincronizarse.
- El logo del header móvil apuntaba a `/platform/dashboard` (redirect) → ahora a `/platform/projects`.

### Vistas dentro de un proyecto (detalle, Tablero, Solicitudes, Bugs, Recursos, Hosting)
- `ProjectShell` / `ProjectSecondarySidebar` (afecta a las 6 a la vez): el secondary sidebar (`w-56` fijo) empujaba el contenido fuera de pantalla. Ahora apila en móvil y vuelve a fila en `lg+`; el `main` lleva `min-w-0` para que las tablas internas no desborden.
- El secondary sidebar pasa a **barra de tabs con scroll horizontal** en móvil, con **barrita indicadora propia** y **auto-scroll al tab activo** (scrollbar nativa oculta, sin degradado).
- `PhaseList`: la fila de fase no encogía el título y el botón de eliminar se salía → título `min-w-0/truncate` y controles `shrink-0`.
- Solicitudes, Bugs, Recursos: misma tabla recortada → **tarjetas en móvil** + tabla `overflow-x-auto` en `md+` (aplica a admin y cliente).

### Detalle de cliente (`/platform/clients/:id`)
- El grid de 2 columnas (sin definir en móvil) crecía a max-content → overflow horizontal. Se fija `grid-cols-1` base y el header (nombre/email) lleva `min-w-0/truncate`.

## Plan de pruebas
- `node frontend/scripts/check-design-tokens.mjs --files <archivos tocados>` → OK en todos.
- Tests unitarios nuevos: `usePlatformNav` (nav por rol, sin rutas muertas) y card móvil de la tabla de proyectos. Tests de sidebar/drawer existentes siguen en verde (14/14).
- Verificación visual con Playwright a **375px** (admin y cliente) en las 7 vistas: **0 overflow horizontal**.
- Desktop **1440px** intacto: sidebars verticales, tablas visibles, indicadores de scroll ocultos.