### PR TITLE
fix(deploy-and-check): export DJANGO_SETTINGS_MODULE so migrate/collectstatic hit prod DB

### DIFF
--- a/.agents/skills/deploy-and-check/SKILL.md
+++ b/.agents/skills/deploy-and-check/SKILL.md
@@ -58,6 +58,20 @@ GIT_CURRENT_BRANCH=$(cd "$PROJECT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev
 BRANCH="${ARGUMENTS:-$GIT_CURRENT_BRANCH}"
 [ -n "$BRANCH" ] || { echo "❌ ERROR: no se pudo determinar la rama actual y no se especificó argumento"; exit 1; }
 
+# Resolve DJANGO_SETTINGS_MODULE EXACTAMENTE como lo corre el servicio de prod.
+# manage.py defaultea a *_dev (SQLite) en varios proyectos del fleet, así que
+# migrate/collectstatic DEBEN usar el módulo de prod o pegan a la base equivocada.
+# Fuente primaria: el Environment= del unit systemd de gunicorn. Fallback: backend/.env.
+# Los pasos 5 (migrate) y 7 (collectstatic) heredan este export.
+DJANGO_SETTINGS_MODULE=$(systemctl show "$GUNICORN_SVC" -p Environment --value 2>/dev/null \
+        | tr ' ' '\n' | grep '^DJANGO_SETTINGS_MODULE=' | head -1 | cut -d= -f2-)
+[ -z "$DJANGO_SETTINGS_MODULE" ] && DJANGO_SETTINGS_MODULE=$(grep -hE '^DJANGO_SETTINGS_MODULE=' \
+        "$PROJECT_DIR/backend/.env" 2>/dev/null | head -1 | cut -d= -f2-)
+export DJANGO_SETTINGS_MODULE
+if [ -z "$DJANGO_SETTINGS_MODULE" ]; then
+    echo "⚠️  DJANGO_SETTINGS_MODULE no resuelto (ni systemd ni .env) — manage.py usará su setdefault (¡puede apuntar a dev/SQLite!)"
+fi
+
 cat <<EOF
 ✅ Discovery OK:
   PROJECT_NAME:    $PROJECT_NAME
@@ -67,6 +81,7 @@ cat <<EOF
   GUNICORN_SVC:    $GUNICORN_SVC
   HUEY_SVC:        $HUEY_SVC
   DB_TYPE:         $DB_TYPE
+  DJANGO_SETTINGS: ${DJANGO_SETTINGS_MODULE:-<unset → manage.py default>}
   HAS_FRONTEND:    $HAS_FRONTEND
   NODE_VERSION:    $NODE_VERSION
   BRANCH:          $BRANCH
@@ -103,6 +118,8 @@ cd "$PROJECT_DIR" && git fetch origin && git checkout "$BRANCH" && git pull orig
 
 5. Backend deps + migrations:
 ```bash
+# migrate corre con el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod,
+# no el *_dev/SQLite que manage.py usaría por default).
 cd "$PROJECT_DIR/backend" && \
     "$PROJECT_DIR/$VENV_PATH" -m pip install -r requirements.txt && \
     "$PROJECT_DIR/$VENV_PATH" manage.py migrate
@@ -129,6 +146,7 @@ fi
 
 7. Collectstatic (si aplica):
 ```bash
+# collectstatic hereda el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod).
 if [ "$COLLECTSTATIC" = "true" ]; then
     cd "$PROJECT_DIR/backend" && "$PROJECT_DIR/$VENV_PATH" manage.py collectstatic --noinput
 fi
@@ -196,3 +214,37 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 - Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
 - Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+
+---
+
+## Output final
+
+Reportar siguiendo [[_output-protocol]]. Plantilla específica de
+`/deploy-and-check`:
+
+```markdown
+🟢 deploy-and-check OK — <proyecto> @ <rama>
+✨ Todo en orden — no hay acciones pendientes.
+
+| Dimensión | Estado | Detalle |
+|---|---|---|
+| Entorno VPS | ✅ | hostname <srv>, no es dev-machine |
+| Phase 0 — Discovery | ✅ | projects.yml leído: <svc>, <dominio>, <env> |
+| Phase 1 — Pre-deploy | ✅ | quick-status OK, working tree clean, rama existe |
+| Phase 2 — Pull & build | ✅ | git pull, pip install, migrate, frontend build |
+| Phase 3 — Restart services | ✅ | gunicorn + huey + (frontend) reiniciados |
+| Phase 4 — Health endpoint | ✅ | curl /api/health/ → 200 OK |
+| Phase 4 — post-deploy-check | ✅ | post-deploy-check.sh PASS para <proyecto> |
+```
+
+Si la verificación de entorno falla (corriendo en dev-machine), reportar
+🚫 con `## Next steps` indicando el SSH al VPS destino — **no es error**,
+es safety gate.
+
+Si gunicorn/huey no levanta, health 5xx, o post-deploy-check FAIL, reemplazar
+✅ por ❌, omitir la línea ✨ y agregar `## Next steps` con los `journalctl
+-u <svc> -n 50` y los logs específicos (`backend/logs/django.log`,
+`/var/log/nginx/error.log`).
+
+**No duplicar contadores con el output del script bash:** el reporte de la
+skill va DESPUÉS de cualquier `print_summary` que emita post-deploy-check.sh.

--- a/.claude/skills/deploy-and-check/SKILL.md
+++ b/.claude/skills/deploy-and-check/SKILL.md
@@ -79,6 +79,20 @@ GIT_CURRENT_BRANCH=$(cd "$PROJECT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev
 BRANCH="${ARGUMENTS:-$GIT_CURRENT_BRANCH}"
 [ -n "$BRANCH" ] || { echo "❌ ERROR: no se pudo determinar la rama actual y no se especificó argumento"; exit 1; }
 
+# Resolve DJANGO_SETTINGS_MODULE EXACTAMENTE como lo corre el servicio de prod.
+# manage.py defaultea a *_dev (SQLite) en varios proyectos del fleet, así que
+# migrate/collectstatic DEBEN usar el módulo de prod o pegan a la base equivocada.
+# Fuente primaria: el Environment= del unit systemd de gunicorn. Fallback: backend/.env.
+# Los pasos 5 (migrate) y 7 (collectstatic) heredan este export.
+DJANGO_SETTINGS_MODULE=$(systemctl show "$GUNICORN_SVC" -p Environment --value 2>/dev/null \
+        | tr ' ' '\n' | grep '^DJANGO_SETTINGS_MODULE=' | head -1 | cut -d= -f2-)
+[ -z "$DJANGO_SETTINGS_MODULE" ] && DJANGO_SETTINGS_MODULE=$(grep -hE '^DJANGO_SETTINGS_MODULE=' \
+        "$PROJECT_DIR/backend/.env" 2>/dev/null | head -1 | cut -d= -f2-)
+export DJANGO_SETTINGS_MODULE
+if [ -z "$DJANGO_SETTINGS_MODULE" ]; then
+    echo "⚠️  DJANGO_SETTINGS_MODULE no resuelto (ni systemd ni .env) — manage.py usará su setdefault (¡puede apuntar a dev/SQLite!)"
+fi
+
 cat <<EOF
 ✅ Discovery OK:
   PROJECT_NAME:    $PROJECT_NAME
@@ -88,6 +102,7 @@ cat <<EOF
   GUNICORN_SVC:    $GUNICORN_SVC
   HUEY_SVC:        $HUEY_SVC
   DB_TYPE:         $DB_TYPE
+  DJANGO_SETTINGS: ${DJANGO_SETTINGS_MODULE:-<unset → manage.py default>}
   HAS_FRONTEND:    $HAS_FRONTEND
   NODE_VERSION:    $NODE_VERSION
   BRANCH:          $BRANCH
@@ -124,6 +139,8 @@ cd "$PROJECT_DIR" && git fetch origin && git checkout "$BRANCH" && git pull orig
 
 5. Backend deps + migrations:
 ```bash
+# migrate corre con el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod,
+# no el *_dev/SQLite que manage.py usaría por default).
 cd "$PROJECT_DIR/backend" && \
     "$PROJECT_DIR/$VENV_PATH" -m pip install -r requirements.txt && \
     "$PROJECT_DIR/$VENV_PATH" manage.py migrate
@@ -150,6 +167,7 @@ fi
 
 7. Collectstatic (si aplica):
 ```bash
+# collectstatic hereda el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod).
 if [ "$COLLECTSTATIC" = "true" ]; then
     cd "$PROJECT_DIR/backend" && "$PROJECT_DIR/$VENV_PATH" manage.py collectstatic --noinput
 fi
@@ -217,3 +235,37 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 - Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
 - Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+
+---
+
+## Output final
+
+Reportar siguiendo [[_output-protocol]]. Plantilla específica de
+`/deploy-and-check`:
+
+```markdown
+🟢 deploy-and-check OK — <proyecto> @ <rama>
+✨ Todo en orden — no hay acciones pendientes.
+
+| Dimensión | Estado | Detalle |
+|---|---|---|
+| Entorno VPS | ✅ | hostname <srv>, no es dev-machine |
+| Phase 0 — Discovery | ✅ | projects.yml leído: <svc>, <dominio>, <env> |
+| Phase 1 — Pre-deploy | ✅ | quick-status OK, working tree clean, rama existe |
+| Phase 2 — Pull & build | ✅ | git pull, pip install, migrate, frontend build |
+| Phase 3 — Restart services | ✅ | gunicorn + huey + (frontend) reiniciados |
+| Phase 4 — Health endpoint | ✅ | curl /api/health/ → 200 OK |
+| Phase 4 — post-deploy-check | ✅ | post-deploy-check.sh PASS para <proyecto> |
+```
+
+Si la verificación de entorno falla (corriendo en dev-machine), reportar
+🚫 con `## Next steps` indicando el SSH al VPS destino — **no es error**,
+es safety gate.
+
+Si gunicorn/huey no levanta, health 5xx, o post-deploy-check FAIL, reemplazar
+✅ por ❌, omitir la línea ✨ y agregar `## Next steps` con los `journalctl
+-u <svc> -n 50` y los logs específicos (`backend/logs/django.log`,
+`/var/log/nginx/error.log`).
+
+**No duplicar contadores con el output del script bash:** el reporte de la
+skill va DESPUÉS de cualquier `print_summary` que emita post-deploy-check.sh.

--- a/.windsurf/workflows/deploy-and-check.md
+++ b/.windsurf/workflows/deploy-and-check.md
@@ -58,6 +58,20 @@ GIT_CURRENT_BRANCH=$(cd "$PROJECT_DIR" && git rev-parse --abbrev-ref HEAD 2>/dev
 BRANCH="${ARGUMENTS:-$GIT_CURRENT_BRANCH}"
 [ -n "$BRANCH" ] || { echo "❌ ERROR: no se pudo determinar la rama actual y no se especificó argumento"; exit 1; }
 
+# Resolve DJANGO_SETTINGS_MODULE EXACTAMENTE como lo corre el servicio de prod.
+# manage.py defaultea a *_dev (SQLite) en varios proyectos del fleet, así que
+# migrate/collectstatic DEBEN usar el módulo de prod o pegan a la base equivocada.
+# Fuente primaria: el Environment= del unit systemd de gunicorn. Fallback: backend/.env.
+# Los pasos 5 (migrate) y 7 (collectstatic) heredan este export.
+DJANGO_SETTINGS_MODULE=$(systemctl show "$GUNICORN_SVC" -p Environment --value 2>/dev/null \
+        | tr ' ' '\n' | grep '^DJANGO_SETTINGS_MODULE=' | head -1 | cut -d= -f2-)
+[ -z "$DJANGO_SETTINGS_MODULE" ] && DJANGO_SETTINGS_MODULE=$(grep -hE '^DJANGO_SETTINGS_MODULE=' \
+        "$PROJECT_DIR/backend/.env" 2>/dev/null | head -1 | cut -d= -f2-)
+export DJANGO_SETTINGS_MODULE
+if [ -z "$DJANGO_SETTINGS_MODULE" ]; then
+    echo "⚠️  DJANGO_SETTINGS_MODULE no resuelto (ni systemd ni .env) — manage.py usará su setdefault (¡puede apuntar a dev/SQLite!)"
+fi
+
 cat <<EOF
 ✅ Discovery OK:
   PROJECT_NAME:    $PROJECT_NAME
@@ -67,6 +81,7 @@ cat <<EOF
   GUNICORN_SVC:    $GUNICORN_SVC
   HUEY_SVC:        $HUEY_SVC
   DB_TYPE:         $DB_TYPE
+  DJANGO_SETTINGS: ${DJANGO_SETTINGS_MODULE:-<unset → manage.py default>}
   HAS_FRONTEND:    $HAS_FRONTEND
   NODE_VERSION:    $NODE_VERSION
   BRANCH:          $BRANCH
@@ -103,6 +118,8 @@ cd "$PROJECT_DIR" && git fetch origin && git checkout "$BRANCH" && git pull orig
 
 5. Backend deps + migrations:
 ```bash
+# migrate corre con el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod,
+# no el *_dev/SQLite que manage.py usaría por default).
 cd "$PROJECT_DIR/backend" && \
     "$PROJECT_DIR/$VENV_PATH" -m pip install -r requirements.txt && \
     "$PROJECT_DIR/$VENV_PATH" manage.py migrate
@@ -129,6 +146,7 @@ fi
 
 7. Collectstatic (si aplica):
 ```bash
+# collectstatic hereda el DJANGO_SETTINGS_MODULE exportado en Phase 0 (módulo de prod).
 if [ "$COLLECTSTATIC" = "true" ]; then
     cd "$PROJECT_DIR/backend" && "$PROJECT_DIR/$VENV_PATH" manage.py collectstatic --noinput
 fi
@@ -196,3 +214,37 @@ sudo systemctl status "$HUEY_SVC" --no-pager -l
 - Skill **genérico** — auto-resuelve servicios, dominios y rutas desde `~/webapps/vps-ops-toolkit/projects.yml`. Funciona para staging y producción.
 - Sin argumento despliega en la rama actual (`git rev-parse --abbrev-ref HEAD`). Con argumento hace checkout a la rama indicada.
 - Fuente canónica: `vps-ops-toolkit/workflows/.claude/deploy-and-check.md`. Las versiones en `.windsurf/` y `.agents/skills/` son copias del mismo contenido.
+
+---
+
+## Output final
+
+Reportar siguiendo [[_output-protocol]]. Plantilla específica de
+`/deploy-and-check`:
+
+```markdown
+🟢 deploy-and-check OK — <proyecto> @ <rama>
+✨ Todo en orden — no hay acciones pendientes.
+
+| Dimensión | Estado | Detalle |
+|---|---|---|
+| Entorno VPS | ✅ | hostname <srv>, no es dev-machine |
+| Phase 0 — Discovery | ✅ | projects.yml leído: <svc>, <dominio>, <env> |
+| Phase 1 — Pre-deploy | ✅ | quick-status OK, working tree clean, rama existe |
+| Phase 2 — Pull & build | ✅ | git pull, pip install, migrate, frontend build |
+| Phase 3 — Restart services | ✅ | gunicorn + huey + (frontend) reiniciados |
+| Phase 4 — Health endpoint | ✅ | curl /api/health/ → 200 OK |
+| Phase 4 — post-deploy-check | ✅ | post-deploy-check.sh PASS para <proyecto> |
+```
+
+Si la verificación de entorno falla (corriendo en dev-machine), reportar
+🚫 con `## Next steps` indicando el SSH al VPS destino — **no es error**,
+es safety gate.
+
+Si gunicorn/huey no levanta, health 5xx, o post-deploy-check FAIL, reemplazar
+✅ por ❌, omitir la línea ✨ y agregar `## Next steps` con los `journalctl
+-u <svc> -n 50` y los logs específicos (`backend/logs/django.log`,
+`/var/log/nginx/error.log`).
+
+**No duplicar contadores con el output del script bash:** el reporte de la
+skill va DESPUÉS de cualquier `print_summary` que emita post-deploy-check.sh.


### PR DESCRIPTION
Sync of the canonical deploy-and-check skill fix from vps-ops-toolkit. Phase 0 resolves DJANGO_SETTINGS_MODULE from the gunicorn systemd unit (Environment=), falling back to backend/.env, and exports it so migrate/collectstatic hit the production DB instead of the manage.py *_dev/SQLite default.