### PR TITLE
FIX: blog prerender — build against a local Django server (bypass nginx rate limit)

### DIFF
--- a/backend/projectapp/settings_build.py
+++ b/backend/projectapp/settings_build.py
@@ -1,0 +1,21 @@
+"""Settings for the build-time blog prerender server.
+
+Used only by the throwaway local Django server that
+``frontend/update-django-template.js`` starts on loopback to prerender blog
+posts (see that file for why). It extends production — same MySQL database and
+real content — but disables HTTPS enforcement so the dev server can be reached
+over plain HTTP on 127.0.0.1 (production forces SECURE_SSL_REDIRECT, which would
+301 the prerender fetches to https and break them).
+
+Never used to serve real traffic.
+"""
+
+from .settings_prod import *  # noqa: F401,F403
+
+# Loopback HTTP build server — no TLS in front of it.
+SECURE_SSL_REDIRECT = False
+SECURE_HSTS_SECONDS = 0
+SECURE_HSTS_INCLUDE_SUBDOMAINS = False
+SECURE_HSTS_PRELOAD = False
+SESSION_COOKIE_SECURE = False
+CSRF_COOKIE_SECURE = False

--- a/frontend/update-django-template.js
+++ b/frontend/update-django-template.js
@@ -1,7 +1,8 @@
 import fs from 'fs';
+import net from 'net';
 import path from 'path';
 import { fileURLToPath } from 'url';
-import { execSync } from 'child_process';
+import { execSync, spawn } from 'child_process';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -11,15 +12,106 @@ const targetDir = path.resolve(__dirname, '../backend/static/frontend');
 const stagingDir = `${targetDir}.new`;
 const retiredDir = `${targetDir}.old`;
 
-// 1. Run nuxt generate with cdnURL set for Django static serving.
-// PRERENDER_BLOG=1 enables blog post prerendering (slugs fetched from the API;
-// see blogPrerenderRoutes in nuxt.config.ts). PRERENDER_API_ORIGIN /
-// PRERENDER_REQUIRE_BLOG are inherited from the caller's environment.
-console.log('Running nuxt generate...');
-execSync('NUXT_APP_CDN_URL=/static/frontend/ PRERENDER_BLOG=1 npx nuxi generate', {
-  cwd: __dirname,
-  stdio: 'inherit',
-});
+const backendDir = path.resolve(__dirname, '../backend');
+const venvPython = path.resolve(backendDir, 'venv/bin/python');
+const managePy = path.resolve(backendDir, 'manage.py');
+
+// ---------------------------------------------------------------------------
+// Blog prerender against a throwaway local Django server.
+//
+// Blog post pages fetch their content from the API during prerender. Pointing
+// that at the public domain routes every request through nginx, whose `api`
+// rate-limit zone (5 r/s) trips 429s once there are more than a handful of
+// posts — silently dropping most prerendered pages. Instead we spin up Django
+// on loopback, prerender against it (no nginx, no rate limit, real DB data),
+// and tear it down. This is the single chokepoint for every build path
+// (deploy and the on-publish rebuild task), so the fix is global.
+//
+// If the backend (venv + manage.py) isn't present — e.g. a pure-frontend CI or
+// dev build — we skip the local server and fall back to PRERENDER_API_ORIGIN
+// from the environment (or no blog prerender), exactly as before.
+// ---------------------------------------------------------------------------
+
+function findFreePort() {
+  return new Promise((resolve, reject) => {
+    const srv = net.createServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, '127.0.0.1', () => {
+      const { port } = srv.address();
+      srv.close(() => resolve(port));
+    });
+  });
+}
+
+async function waitForApi(origin, timeoutMs = 60000) {
+  const deadline = Date.now() + timeoutMs;
+  const url = `${origin}/api/blog/sitemap-data/`;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(url);
+      if (res.ok) return true;
+    } catch {
+      // server not up yet
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
+async function startLocalDjango() {
+  const port = await findFreePort();
+  const origin = `http://127.0.0.1:${port}`;
+  const env = {
+    ...process.env,
+    // Dedicated build settings: production DB + data, but no HTTPS enforcement
+    // (production's SECURE_SSL_REDIRECT would 301 the loopback prerender fetches
+    // to https and break them). See backend/projectapp/settings_build.py.
+    DJANGO_SETTINGS_MODULE: 'projectapp.settings_build',
+    // Loopback-only server; allow the host it will actually be reached on.
+    DJANGO_ALLOWED_HOSTS: '127.0.0.1,localhost',
+  };
+  console.log(`[blog-prerender] starting local Django on ${origin} (settings=${env.DJANGO_SETTINGS_MODULE})`);
+  const proc = spawn(
+    venvPython,
+    ['manage.py', 'runserver', `127.0.0.1:${port}`, '--noreload', '--skip-checks'],
+    { cwd: backendDir, env, stdio: ['ignore', 'inherit', 'inherit'] },
+  );
+  const ready = await waitForApi(origin);
+  if (!ready) {
+    try { proc.kill('SIGKILL'); } catch { /* noop */ }
+    throw new Error(`local Django did not become ready on ${origin} within timeout`);
+  }
+  console.log(`[blog-prerender] local Django ready on ${origin}`);
+  return { origin, proc };
+}
+
+// 1. Run nuxt generate with cdnURL set for Django static serving, prerendering
+//    blog posts against a local backend when one is available.
+const baseEnv = { ...process.env, NUXT_APP_CDN_URL: '/static/frontend/' };
+let server = null;
+
+const backendAvailable = fs.existsSync(venvPython) && fs.existsSync(managePy);
+if (backendAvailable) {
+  server = await startLocalDjango();
+}
+
+try {
+  const generateEnv = { ...baseEnv, PRERENDER_BLOG: '1' };
+  if (server) {
+    generateEnv.PRERENDER_API_ORIGIN = server.origin;
+    // The local server removes the rate-limit excuse: a dropped prerender is
+    // now a real regression, so fail the build instead of shipping silently.
+    generateEnv.PRERENDER_REQUIRE_BLOG = '1';
+  }
+  console.log('Running nuxt generate...');
+  execSync('npx nuxi generate', { cwd: __dirname, stdio: 'inherit', env: generateEnv });
+} finally {
+  if (server) {
+    console.log('[blog-prerender] stopping local Django');
+    try { server.proc.kill('SIGTERM'); } catch { /* noop */ }
+  }
+}
 
 // 2. Verify output exists
 if (!fs.existsSync(sourceDir)) {


### PR DESCRIPTION
## Problema

`build:django` prerenderiza cada post del blog haciendo `$fetch` a la API. Al apuntar al dominio público, cada request pasaba por nginx, cuyo rate limit de `/api/` (5 r/s, burst 10) devolvía **429** para todos menos los primeros ~10 de las 114 rutas de blog. Esas páginas daban 500 y el build terminaba **sin** los posts prerenderizados (sin HTML por post ni meta/OG tags para crawlers y previews de WhatsApp/redes).

Esto afectaba **todos** los builds (deploy y la tarea de rebuild-al-publicar), porque ambos pasan por el mismo `build:django`.

## Solución

`frontend/update-django-template.js` ahora levanta un Django temporal en loopback (`settings_build`: misma DB/datos de prod, pero sin forzar HTTPS para poder hablarle por HTTP en 127.0.0.1), prerenderiza contra él y lo apaga. Sin nginx, sin rate limit, con contenido real. Es el único punto por donde pasan todos los builds, así que el fix es global. Si no hay backend (venv + manage.py) — p.ej. CI/dev — hace fallback al comportamiento previo.

Nuevo: `backend/projectapp/settings_build.py` (extiende `settings_prod`, desactiva SSL redirect/HSTS/secure-cookies — solo para el server de build en loopback, nunca sirve tráfico real).

## Verificación

- `build:django` local: **114 rutas de blog prerenderizadas, 0 errores** (antes: ~100 daban 500 por 429).
- HTML servido en vivo de un post: ahora trae `<article>` + `og:title` por post + JSON-LD (antes solo el shell SPA).