### PR TITLE
FIX: proposal delete (409 on linked), refresh cache, open-notification suppression, expired-banner overlap

### DIFF
--- a/backend/content/management/commands/diagnose_proposal_notifications.py
+++ b/backend/content/management/commands/diagnose_proposal_notifications.py
@@ -1,0 +1,208 @@
+"""
+Diagnose the "client opened the proposal" notification pipeline.
+
+The sales team reported not receiving first-view / stakeholder notifications.
+Those emails are queued as Huey tasks (async in production) and sent over
+SMTP, so a silent failure can live in several places: the Huey worker not
+running, SMTP credentials, a disabled email template, or empty recipients.
+
+This command inspects each link of the chain and (optionally) sends a real
+test email so the exact failing step is identified end to end.
+
+Usage:
+    python manage.py diagnose_proposal_notifications
+    python manage.py diagnose_proposal_notifications --send --to you@example.com
+    python manage.py diagnose_proposal_notifications --proposal-id 123 --send
+"""
+
+from django.conf import settings
+from django.core.mail import EmailMultiAlternatives
+from django.core.management.base import BaseCommand
+
+from content.models import BusinessProposal
+from content.services.proposal_email_service import ProposalEmailService
+
+
+class Command(BaseCommand):
+    help = (
+        'Diagnose the proposal open-notification pipeline '
+        '(Huey, SMTP, templates, recipients) and optionally send a test email.'
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            '--send',
+            action='store_true',
+            help='Actually attempt to send a test email over SMTP.',
+        )
+        parser.add_argument(
+            '--to',
+            type=str,
+            default=None,
+            help='Override recipient for the SMTP test (defaults to the '
+                 'configured notification recipients).',
+        )
+        parser.add_argument(
+            '--proposal-id',
+            type=int,
+            default=None,
+            help='Also exercise the real first-view notification template '
+                 'path for this proposal id.',
+        )
+
+    # -- helpers ---------------------------------------------------------
+
+    def _ok(self, msg):
+        self.stdout.write(self.style.SUCCESS(f'  ✓ {msg}'))
+
+    def _warn(self, msg):
+        self.stdout.write(self.style.WARNING(f'  ⚠ {msg}'))
+
+    def _err(self, msg):
+        self.stdout.write(self.style.ERROR(f'  ✗ {msg}'))
+
+    def _section(self, title):
+        self.stdout.write('')
+        self.stdout.write(self.style.MIGRATE_HEADING(title))
+
+    # -- handle ----------------------------------------------------------
+
+    def handle(self, *args, **options):
+        self.stdout.write(
+            self.style.HTTP_INFO('Proposal notification pipeline diagnosis')
+        )
+
+        self._check_huey()
+        self._check_email_settings()
+        recipients = self._check_recipients()
+        self._check_templates()
+
+        if options['proposal_id']:
+            self._check_template_render(options['proposal_id'])
+
+        if options['send']:
+            self._send_test_email(options['to'], recipients)
+        else:
+            self._section('5. SMTP delivery')
+            self.stdout.write(
+                '  (skipped — pass --send to attempt a real test email)'
+            )
+
+        self.stdout.write('')
+        self.stdout.write(self.style.HTTP_INFO('Diagnosis complete.'))
+
+    # -- checks ----------------------------------------------------------
+
+    def _check_huey(self):
+        self._section('1. Huey async queue')
+        huey = getattr(settings, 'HUEY', None)
+        if huey is None:
+            self._err('settings.HUEY is not configured.')
+            return
+        immediate = getattr(huey, 'immediate', None)
+        if immediate:
+            self._ok('immediate=True — tasks run synchronously (dev/staging). '
+                     'No worker required.')
+        else:
+            self._warn('immediate=False — a Huey worker must be running '
+                       '(projectapp-huey.service). If it is down, '
+                       'notifications never execute.')
+            try:
+                pending = huey.pending_count()
+                if pending:
+                    self._warn(f'{pending} task(s) pending in the queue — '
+                               'consistent with a stopped/slow worker.')
+                else:
+                    self._ok('0 tasks pending in the queue.')
+            except Exception as exc:  # pragma: no cover - storage backend dependent
+                self._warn(f'Could not read pending task count: {exc}')
+
+    def _check_email_settings(self):
+        self._section('2. Email backend / SMTP settings')
+        backend = getattr(settings, 'EMAIL_BACKEND', '')
+        self.stdout.write(f'  EMAIL_BACKEND = {backend}')
+        if 'console' in backend or 'locmem' in backend or 'dummy' in backend:
+            self._warn('Non-SMTP backend — emails are not actually delivered.')
+        else:
+            self._ok('SMTP backend configured.')
+        self.stdout.write(
+            f'  EMAIL_HOST = {getattr(settings, "EMAIL_HOST", "")}:'
+            f'{getattr(settings, "EMAIL_PORT", "")} '
+            f'(SSL={getattr(settings, "EMAIL_USE_SSL", False)}, '
+            f'TLS={getattr(settings, "EMAIL_USE_TLS", False)})'
+        )
+        user = getattr(settings, 'EMAIL_HOST_USER', '')
+        pwd = getattr(settings, 'EMAIL_HOST_PASSWORD', '')
+        if user:
+            self._ok(f'EMAIL_HOST_USER set ({user}).')
+        else:
+            self._err('EMAIL_HOST_USER is empty.')
+        if pwd:
+            self._ok('EMAIL_HOST_PASSWORD set.')
+        else:
+            self._err('EMAIL_HOST_PASSWORD is empty.')
+        self.stdout.write(
+            f'  DEFAULT_FROM_EMAIL = {getattr(settings, "DEFAULT_FROM_EMAIL", "")}'
+        )
+
+    def _check_recipients(self):
+        self._section('3. Notification recipients')
+        recipients = ProposalEmailService._get_notification_recipients()
+        if recipients:
+            self._ok(f'Recipients: {", ".join(recipients)}')
+        else:
+            self._err('No notification recipients resolved.')
+        return recipients
+
+    def _check_templates(self):
+        self._section('4. Email templates active')
+        for key in ('proposal_first_view_notification',
+                    'proposal_stakeholder_detected'):
+            try:
+                active = ProposalEmailService._is_template_active(key)
+            except Exception as exc:
+                self._err(f'{key}: error checking — {exc}')
+                continue
+            if active:
+                self._ok(f'{key}: active')
+            else:
+                self._warn(f'{key}: DISABLED — notifications of this type are '
+                           'skipped before any send is attempted.')
+
+    def _check_template_render(self, proposal_id):
+        self._section(f'4b. Render first-view template for proposal {proposal_id}')
+        try:
+            proposal = BusinessProposal.objects.get(pk=proposal_id)
+        except BusinessProposal.DoesNotExist:
+            self._err(f'Proposal {proposal_id} not found.')
+            return
+        try:
+            sent = ProposalEmailService.send_first_view_notification(proposal)
+            if sent:
+                self._ok('send_first_view_notification returned True '
+                         '(rendered + sent).')
+            else:
+                self._warn('send_first_view_notification returned False '
+                           '(template disabled, status suppressed, or send '
+                           'failed — see logs above).')
+        except Exception as exc:
+            self._err(f'Exception while rendering/sending: {exc!r}')
+
+    def _send_test_email(self, to_override, recipients):
+        self._section('5. SMTP delivery (live test)')
+        to = [to_override] if to_override else recipients
+        if not to:
+            self._err('No recipient available for the test send.')
+            return
+        try:
+            msg = EmailMultiAlternatives(
+                subject='[diagnose] Proposal notifications SMTP test',
+                body='This is a connectivity test from '
+                     'diagnose_proposal_notifications.',
+                from_email=ProposalEmailService._get_from_email(),
+                to=to,
+            )
+            msg.send(fail_silently=False)
+            self._ok(f'Test email sent to {", ".join(to)} without raising.')
+        except Exception as exc:
+            self._err(f'SMTP send failed: {exc!r}')

--- a/backend/content/services/proposal_email_service.py
+++ b/backend/content/services/proposal_email_service.py
@@ -1059,6 +1059,13 @@ class ProposalEmailService:
         opens a proposal for the first time. This is the ideal moment
         for the sales team to do follow-up.
         """
+        from content.services.proposal_service import ProposalService
+        if ProposalService.open_notifications_suppressed(proposal):
+            logger.info(
+                'Skipping proposal_first_view_notification: proposal %s is %s',
+                proposal.uuid, proposal.status,
+            )
+            return False
         if not cls._is_template_active('proposal_first_view_notification'):
             logger.info('Skipping proposal_first_view_notification: template disabled')
             return False
@@ -1610,6 +1617,13 @@ class ProposalEmailService:
         Notify the sales team when the proposal is accessed from a new
         IP address, suggesting a secondary decision-maker is reviewing it.
         """
+        from content.services.proposal_service import ProposalService
+        if ProposalService.open_notifications_suppressed(proposal):
+            logger.info(
+                'Skipping proposal_stakeholder_detected: proposal %s is %s',
+                proposal.uuid, proposal.status,
+            )
+            return False
         if not cls._is_template_active('proposal_stakeholder_detected'):
             logger.info('Skipping proposal_stakeholder_detected: template disabled')
             return False

--- a/backend/content/services/proposal_service.py
+++ b/backend/content/services/proposal_service.py
@@ -2574,6 +2574,21 @@ class ProposalService:
     DEFAULT_EXPIRATION_DAYS = 21
 
     @staticmethod
+    def open_notifications_suppressed(proposal):
+        """Whether "client opened the proposal" notifications should be skipped.
+
+        We don't notify on opens once the proposal is in a closed/won state:
+        accepted or finished. At that point the open-tracking signal no longer
+        helps the sales team and only produces noise (e.g. the owner revisiting
+        an old, already-accepted proposal).
+        """
+        from content.models import BusinessProposal
+        return proposal.status in (
+            BusinessProposal.Status.ACCEPTED,
+            BusinessProposal.Status.FINISHED,
+        )
+
+    @staticmethod
     def _require_valid_client_email(proposal):
         """Raise ValueError if proposal lacks a deliverable client_email."""
         if not proposal.client_email:

--- a/backend/content/tasks.py
+++ b/backend/content/tasks.py
@@ -1064,6 +1064,7 @@ def notify_first_view(proposal_id):
     """
     from content.models import BusinessProposal
     from content.services.proposal_email_service import ProposalEmailService
+    from content.services.proposal_service import ProposalService
 
     try:
         proposal = BusinessProposal.objects.get(pk=proposal_id)
@@ -1071,6 +1072,14 @@ def notify_first_view(proposal_id):
         logger.warning(
             'Proposal %s not found for first-view notification task.',
             proposal_id,
+        )
+        return
+
+    # Defense in depth: never notify opens on closed proposals.
+    if ProposalService.open_notifications_suppressed(proposal):
+        logger.info(
+            'Skipping first-view notification for proposal %s (status=%s).',
+            proposal.uuid, proposal.status,
         )
         return
 

--- a/backend/content/tests/services/test_open_notification_suppression.py
+++ b/backend/content/tests/services/test_open_notification_suppression.py
@@ -41,7 +41,7 @@ def test_notify_first_view_task_skips_closed_proposal():
     ) as mock_send:
         from content.tasks import notify_first_view
         notify_first_view.call_local(proposal.id)
-    mock_send.assert_not_called()
+    assert mock_send.call_count == 0
 
 
 def test_notify_first_view_task_runs_for_open_proposal():
@@ -52,7 +52,7 @@ def test_notify_first_view_task_runs_for_open_proposal():
     ) as mock_send:
         from content.tasks import notify_first_view
         notify_first_view.call_local(proposal.id)
-    mock_send.assert_called_once()
+    assert mock_send.call_count == 1
 
 
 def test_send_first_view_notification_returns_false_for_closed():

--- a/backend/content/tests/test_open_notification_suppression.py
+++ b/backend/content/tests/test_open_notification_suppression.py
@@ -1,0 +1,62 @@
+"""Tests for open-notification suppression.
+
+"Client opened the proposal" notifications must be skipped when the proposal
+is already closed (accepted/finished), so revisiting an old won proposal does
+not spam the sales team.
+"""
+from unittest.mock import patch
+
+import pytest
+
+from content.models import BusinessProposal
+from content.services.proposal_service import ProposalService
+
+pytestmark = pytest.mark.django_db
+
+
+def _make_proposal(status):
+    return BusinessProposal.objects.create(
+        title='P', client_name='C', status=status,
+    )
+
+
+@pytest.mark.parametrize('status,expected', [
+    ('accepted', True),
+    ('finished', True),
+    ('sent', False),
+    ('viewed', False),
+    ('negotiating', False),
+    ('expired', False),
+])
+def test_open_notifications_suppressed_by_status(status, expected):
+    proposal = _make_proposal(status)
+    assert ProposalService.open_notifications_suppressed(proposal) is expected
+
+
+def test_notify_first_view_task_skips_closed_proposal():
+    proposal = _make_proposal('accepted')
+    with patch(
+        'content.services.proposal_email_service.ProposalEmailService'
+        '.send_first_view_notification'
+    ) as mock_send:
+        from content.tasks import notify_first_view
+        notify_first_view.call_local(proposal.id)
+    mock_send.assert_not_called()
+
+
+def test_notify_first_view_task_runs_for_open_proposal():
+    proposal = _make_proposal('viewed')
+    with patch(
+        'content.services.proposal_email_service.ProposalEmailService'
+        '.send_first_view_notification'
+    ) as mock_send:
+        from content.tasks import notify_first_view
+        notify_first_view.call_local(proposal.id)
+    mock_send.assert_called_once()
+
+
+def test_send_first_view_notification_returns_false_for_closed():
+    from content.services.proposal_email_service import ProposalEmailService
+    proposal = _make_proposal('finished')
+    # Should bail out on status before even checking the template.
+    assert ProposalEmailService.send_first_view_notification(proposal) is False

--- a/backend/content/tests/views/test_proposal_delete.py
+++ b/backend/content/tests/views/test_proposal_delete.py
@@ -1,0 +1,48 @@
+"""Tests for the proposal delete endpoint.
+
+Covers the ProtectedError handling: proposals linked to a launched project
+(via ProjectPhase, on_delete=PROTECT) must return a clear 409 instead of a
+500, while unlinked proposals delete normally.
+"""
+import pytest
+from django.contrib.auth import get_user_model
+from django.urls import reverse
+
+from content.models import BusinessProposal
+
+User = get_user_model()
+pytestmark = pytest.mark.django_db
+
+
+def test_delete_proposal_without_links_returns_204(admin_client, proposal):
+    url = reverse('delete-proposal', args=[proposal.id])
+    response = admin_client.delete(url)
+    assert response.status_code == 204
+    assert not BusinessProposal.objects.filter(id=proposal.id).exists()
+
+
+def test_delete_proposal_with_project_phase_returns_409(admin_client, proposal):
+    from accounts.models import Project, ProjectPhase
+
+    client_user = User.objects.create_user(
+        username='client@example.com', email='client@example.com', password='x',
+    )
+    project = Project.objects.create(name='Launched project', client=client_user)
+    ProjectPhase.objects.create(
+        project=project, business_proposal=proposal, order=1,
+    )
+
+    url = reverse('delete-proposal', args=[proposal.id])
+    response = admin_client.delete(url)
+
+    assert response.status_code == 409
+    assert 'error' in response.data
+    assert 'Launched project' in response.data['error']
+    # Proposal must survive the blocked delete.
+    assert BusinessProposal.objects.filter(id=proposal.id).exists()
+
+
+def test_delete_proposal_not_found_returns_404(admin_client):
+    url = reverse('delete-proposal', args=[999999])
+    response = admin_client.delete(url)
+    assert response.status_code == 404

--- a/backend/content/views/proposal.py
+++ b/backend/content/views/proposal.py
@@ -4,6 +4,7 @@ import re
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 
 from django.conf import settings
+from django.db.models.deletion import ProtectedError
 from django.shortcuts import get_object_or_404
 from django.utils import timezone
 from django.utils.dateparse import parse_datetime
@@ -578,8 +579,15 @@ def _serve_public_proposal(request, proposal):
 
         proposal.save(update_fields=update_fields)
 
-    # Send real-time notification to sales team on first view (async)
-    if is_first_view and not is_preview:
+    # Send real-time notification to sales team on first view (async).
+    # Skip for admin previews and for already-closed proposals
+    # (accepted/finished), where open-tracking is just noise.
+    from content.services.proposal_service import ProposalService
+    if (
+        is_first_view
+        and not is_preview
+        and not ProposalService.open_notifications_suppressed(proposal)
+    ):
         try:
             from content.tasks import notify_first_view
             notify_first_view(proposal.id)
@@ -1685,9 +1693,34 @@ def update_proposal(request, proposal_id):
 def delete_proposal(request, proposal_id):
     """
     Delete a proposal and all related sections/groups (CASCADE).
+
+    Proposals that were launched to the platform are referenced by
+    ``ProjectPhase`` rows via ``on_delete=PROTECT`` (see accounts.models).
+    Deleting such a proposal raises ProtectedError; we surface a clear
+    409 instead of a 500 so the admin understands the link must be
+    removed first.
     """
     proposal = get_object_or_404(BusinessProposal, pk=proposal_id)
-    proposal.delete()
+    try:
+        proposal.delete()
+    except ProtectedError:
+        phases = proposal.project_phases.select_related('project').all()
+        phase_labels = [
+            f'{ph.project.name} (fase {ph.order})'
+            if getattr(ph, 'project', None) else f'fase {ph.order}'
+            for ph in phases
+        ]
+        detail = (
+            'No se puede eliminar esta propuesta porque está vinculada a un '
+            'proyecto lanzado a la plataforma'
+        )
+        if phase_labels:
+            detail += ': ' + ', '.join(phase_labels)
+        detail += '. Desvincula el proyecto antes de eliminarla.'
+        return Response(
+            {'error': detail},
+            status=status.HTTP_409_CONFLICT,
+        )
     return Response(status=status.HTTP_204_NO_CONTENT)
 
 
@@ -2842,7 +2875,15 @@ def track_proposal_engagement(request, proposal_uuid):
     # --- Stakeholder detection ---
     # If this is a new session from a different IP than previous sessions,
     # it may indicate a secondary decision-maker is reviewing the proposal.
-    if _created and not proposal.stakeholder_alert_sent_at and proposal.first_viewed_at:
+    # Skip for already-closed proposals (accepted/finished) — revisiting an
+    # old won proposal shouldn't trigger "someone is reviewing" alerts.
+    from content.services.proposal_service import ProposalService
+    if (
+        _created
+        and not proposal.stakeholder_alert_sent_at
+        and proposal.first_viewed_at
+        and not ProposalService.open_notifications_suppressed(proposal)
+    ):
         known_ips = set(
             ProposalViewEvent.objects
             .filter(proposal=proposal)

--- a/docs/USER_FLOW_MAP.md
+++ b/docs/USER_FLOW_MAP.md
@@ -860,16 +860,35 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
 - **Role:** admin
 - **Priority:** P2
 - **Routes:** `/panel/proposals/`
-- **Description:** Delete an existing business proposal.
+- **Description:** Delete an existing business proposal from the proposals list.
 - **Steps:**
   1. Admin views the proposal list.
   2. Admin clicks delete on a proposal.
-  3. Confirmation dialog appears.
+  3. A confirmation modal appears requiring the admin to type `DELETE`.
   4. Admin confirms deletion.
   5. API call to `DELETE /api/proposals/:id/delete/`.
-  6. Proposal is removed from the list.
-- **Coverage:** ✅ Covered
+  6. On success: proposal is removed (list refreshed) and a success toast shows.
+  7. On `409 Conflict` (proposal linked to a launched project via `ProjectPhase`, `on_delete=PROTECT`): the proposal stays and an error toast shows the backend message.
+- **Coverage:** ⚠️ Partial
 - **E2E Spec:** `e2e/admin/admin-proposal-delete.spec.js`
+- **Known gaps:** The existing spec only navigates + mocks the endpoint; it does not exercise the confirm modal (type `DELETE`), the success toast + list refresh, or the `409` blocked-delete path for project-linked proposals.
+
+### FLOW: `admin-proposal-delete-from-client`
+
+- **Module:** admin
+- **Role:** admin
+- **Priority:** P2
+- **Routes:** `/panel/clients/`
+- **Description:** Delete a specific proposal from a client's expanded row in the Mini-CRM clients view.
+- **Steps:**
+  1. Admin opens `/panel/clients` and expands a client row to see its linked proposals.
+  2. Admin clicks delete on a specific proposal.
+  3. A confirmation modal appears requiring the admin to type `DELETE`.
+  4. Admin confirms → `DELETE /api/proposals/:id/delete/`.
+  5. On success: the client detail is refetched (proposal disappears) and a success toast shows.
+  6. On `409 Conflict` (linked to a launched project): the proposal stays and an error toast shows.
+- **Coverage:** ❌ Missing
+- **E2E Spec:** _none yet (suggested: `e2e/admin/admin-proposal-delete-from-client.spec.js`)_
 
 ### FLOW: `admin-proposal-duplicate`
 
@@ -1022,9 +1041,11 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
   4. Admin uses tab buttons (Todos/Activos/Huérfanos) to filter — sends `?orphans=true/false`.
   5. Admin searches clients by name, email, or company.
   6. Admin expands a client row to view individual proposals (lazy-loaded via `GET /api/proposals/client-profiles/:id/`).
-- **Coverage:** ✅ Covered
+  7. Pressing the global panel refresh button invalidates the per-client detail cache and refetches expanded rows, so renamed/reassigned proposals show up.
+- **Coverage:** ⚠️ Partial
 - **E2E Spec:** `e2e/admin/admin-mini-crm-clients.spec.js`
 - **Backend Tests:** `content/tests/views/test_proposal_clients_views.py`
+- **Known gaps:** No E2E asserts that the refresh button re-fetches an already-expanded client's proposals (the cache-invalidation fix for stale rename/reassignment); see also `admin-proposal-delete-from-client`.
 
 ### FLOW: `admin-client-create-standalone`
 
@@ -1430,6 +1451,7 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
   - [Branch A — Post-rejection revisit] If the proposal was rejected and the client revisits, a `post_rejection_revisit` alert is also created.
 - **Coverage:** ✅ Covered
 - **E2E Spec:** `e2e/proposal/proposal-view.spec.js` (Branch A — Proposal expired)
+- **Known gaps:** When the full proposal still renders with the persistent expired banner (`pages/proposal/[uuid]/index.vue` `isExpired`), the top-left index toggle must drop below the banner (`ProposalIndex` `bannerActive` → `top-28 sm:top-20`) so the two don't overlap. No E2E asserts this no-overlap; only a unit test (`test/components/ProposalIndex.test.js`) covers the offset class.
 
 ### FLOW: `proposal-magic-link-request`
 

--- a/frontend/components/BusinessProposal/ProposalIndex.vue
+++ b/frontend/components/BusinessProposal/ProposalIndex.vue
@@ -3,10 +3,11 @@
     <!-- Toggle button (always visible) -->
     <button
       data-testid="index-toggle"
-      class="index-toggle absolute left-4 top-4 z-50 pointer-events-auto
+      class="index-toggle absolute left-4 z-50 pointer-events-auto
              w-10 h-10 rounded-full bg-surface/90 backdrop-blur-sm shadow-lg
              flex items-center justify-center text-text-brand
-             hover:bg-primary/5 transition-colors"
+             hover:bg-primary/5 transition-all"
+      :class="bannerActive ? 'top-28 sm:top-20' : 'top-4'"
       @click="isOpen = !isOpen"
     >
       <svg v-if="!isOpen" class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -140,6 +141,12 @@ defineProps({
   language: {
     type: String,
     default: 'es',
+  },
+  // When a full-width fixed banner (e.g. the expired-proposal notice) is
+  // shown at the top, drop the toggle button below it so they don't overlap.
+  bannerActive: {
+    type: Boolean,
+    default: false,
   },
 });
 

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -225,7 +225,7 @@
       ],
       "priority": "P2",
       "description": "From /panel/clients, expand a client row and delete a specific linked proposal. A confirm modal requires typing 'DELETE'; on success the client detail is refetched (proposal disappears) and a success toast shows; on 409 (linked to a launched project) the proposal stays and an error toast shows.",
-      "expectedSpecs": 1,
+      "expectedSpecs": 0,
       "knownGaps": "No dedicated spec yet (suggested e2e/admin/admin-proposal-delete-from-client.spec.js). The delete-from-client confirm modal, detail refetch, and 409 path are unasserted."
     },
     "admin-proposal-send": {

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -213,8 +213,20 @@
         "admin"
       ],
       "priority": "P2",
-      "description": "Delete an existing business proposal.",
-      "expectedSpecs": 1
+      "description": "Delete an existing business proposal from /panel/proposals. A confirm modal requires typing 'DELETE'; on success the list refreshes and a success toast shows; on 409 (proposal linked to a launched project via ProjectPhase on_delete=PROTECT) the proposal stays and an error toast surfaces the backend message.",
+      "expectedSpecs": 1,
+      "knownGaps": "The spec only navigates + mocks DELETE; it does not exercise the confirm modal (type 'DELETE'), the success toast + list refresh, or the 409 blocked-delete path for project-linked proposals."
+    },
+    "admin-proposal-delete-from-client": {
+      "name": "Admin Proposal Delete From Client",
+      "module": "admin",
+      "roles": [
+        "admin"
+      ],
+      "priority": "P2",
+      "description": "From /panel/clients, expand a client row and delete a specific linked proposal. A confirm modal requires typing 'DELETE'; on success the client detail is refetched (proposal disappears) and a success toast shows; on 409 (linked to a launched project) the proposal stays and an error toast shows.",
+      "expectedSpecs": 1,
+      "knownGaps": "No dedicated spec yet (suggested e2e/admin/admin-proposal-delete-from-client.spec.js). The delete-from-client confirm modal, detail refetch, and 409 path are unasserted."
     },
     "admin-proposal-send": {
       "name": "Admin Proposal Send",
@@ -434,8 +446,9 @@
         "admin"
       ],
       "priority": "P2",
-      "description": "View client list with search, tab filtering (Todos/Activos/Huérfanos), expand client to see linked proposals, and empty state.",
-      "expectedSpecs": 3
+      "description": "View client list with search, tab filtering (Todos/Activos/Huérfanos), expand client to see linked proposals, and empty state. The global panel refresh button invalidates the per-client detail cache and refetches expanded rows so renamed/reassigned proposals appear.",
+      "expectedSpecs": 3,
+      "knownGaps": "No E2E asserts that the refresh button re-fetches an already-expanded client's proposals (the cache-invalidation fix for stale rename/reassignment)."
     },
     "admin-portfolio-list": {
       "name": "Admin Portfolio List",
@@ -761,7 +774,8 @@
       ],
       "priority": "P1",
       "description": "Expired proposal returns 410 with partial data; frontend renders ProposalExpired with client name, WhatsApp CTA, and email contact.",
-      "expectedSpecs": 1
+      "expectedSpecs": 1,
+      "knownGaps": "When the full proposal still renders with the persistent expired banner (pages/proposal/[uuid]/index.vue isExpired), the top-left index toggle must drop below the banner (ProposalIndex bannerActive → top-28 sm:top-20). No E2E asserts this no-overlap; only a unit test covers the offset class."
     },
     "admin-proposal-batch-actions": {
       "name": "Admin Proposal Batch Actions",

--- a/frontend/pages/panel/clients/index.vue
+++ b/frontend/pages/panel/clients/index.vue
@@ -533,6 +533,9 @@
       @confirm="handleConfirmed"
       @cancel="handleCancelled"
     />
+
+    <!-- Global panel toast (success/error feedback) -->
+    <PanelToast />
   </div>
 </template>
 
@@ -541,12 +544,14 @@ import { ref, reactive, computed, onMounted, onBeforeUnmount, watch } from 'vue'
 import { PlusIcon, TrashIcon, PencilSquareIcon } from '@heroicons/vue/24/outline';
 import SidebarIcon from '~/components/platform/SidebarIcon.vue';
 import ConfirmModal from '~/components/ConfirmModal.vue';
+import PanelToast from '~/components/panel/PanelToast.vue';
 import ClientFilterPanel from '~/components/clients/ClientFilterPanel.vue';
 import ProposalFilterTabs from '~/components/proposals/ProposalFilterTabs.vue';
 import BasePagination from '~/components/base/BasePagination.vue';
 import { useConfirmModal } from '~/composables/useConfirmModal';
 import { useClientFilters } from '~/composables/useClientFilters';
 import { usePanelRefresh } from '~/composables/usePanelRefresh';
+import { usePanelToast } from '~/composables/usePanelToast';
 import { usePanelToPlatformBridge } from '~/composables/usePanelToPlatformBridge';
 import { usePagination } from '~/composables/usePagination';
 import { useProposalClientsStore } from '~/stores/proposalClients';
@@ -562,6 +567,7 @@ const proposalStore = useProposalStore();
 const diagnosticsStore = useDiagnosticsStore();
 const { confirmState, requestConfirm, handleConfirmed, handleCancelled } =
   useConfirmModal();
+const { showToast } = usePanelToast();
 
 const {
   currentFilters,
@@ -620,6 +626,27 @@ async function loadClients() {
   await clientsStore.fetchClients({ search: search.value.trim(), orphans });
 }
 
+/**
+ * Full refresh bound to the global panel refresh button.
+ *
+ * Besides reloading the top-level rows, it invalidates the per-client
+ * detail cache and refetches the rows that are still expanded. Without
+ * this, renaming a proposal or reassigning it to another client would
+ * not show up after refresh because the nested proposals are served from
+ * `detailCache`, which is only populated once on expand.
+ */
+async function refreshAll() {
+  await loadClients();
+  const expandedIds = Array.from(expandedClients.value);
+  Object.keys(detailCache).forEach((key) => { delete detailCache[key]; });
+  await Promise.all(
+    expandedIds.map(async (id) => {
+      const result = await clientsStore.fetchClient(id);
+      if (result.success) detailCache[id] = result.data;
+    }),
+  );
+}
+
 function setActiveTab(tabId) {
   activeTab.value = tabId;
   loadClients();
@@ -649,7 +676,7 @@ onMounted(() => {
   document.addEventListener('keydown', handleEditEscape);
 });
 
-usePanelRefresh(loadClients);
+usePanelRefresh(refreshAll);
 onBeforeUnmount(() => {
   if (searchTimer) clearTimeout(searchTimer);
   document.removeEventListener('keydown', handleEditEscape);
@@ -823,7 +850,15 @@ function confirmDeleteProposal(client, proposal) {
     requireTypeText: 'DELETE',
     onConfirm: async () => {
       const result = await proposalStore.deleteProposal(proposal.id);
-      if (result.success) await refreshClientDetail(client.id);
+      if (result.success) {
+        await refreshClientDetail(client.id);
+        showToast({ type: 'success', text: 'Propuesta eliminada.' });
+      } else {
+        showToast({
+          type: 'error',
+          text: result.error || 'No se pudo eliminar la propuesta.',
+        });
+      }
     },
   });
 }

--- a/frontend/pages/panel/proposals/index.vue
+++ b/frontend/pages/panel/proposals/index.vue
@@ -1290,10 +1290,23 @@ function handleCopyLink(p) {
 function handleDelete(id) {
   requestConfirm({
     title: 'Eliminar propuesta',
-    message: '¿Eliminar esta propuesta? Esta acción no se puede deshacer.',
+    message: 'Esto eliminará la propuesta de forma permanente. Esta acción no se puede deshacer.',
     variant: 'danger',
     confirmText: 'Eliminar',
-    onConfirm: () => proposalStore.deleteProposal(id),
+    cancelText: 'Cancelar',
+    requireTypeText: 'DELETE',
+    onConfirm: async () => {
+      const result = await proposalStore.deleteProposal(id);
+      if (result.success) {
+        await refreshData();
+        showStatusToast('Propuesta eliminada.', 'success');
+      } else {
+        showStatusToast(
+          result.error || 'No se pudo eliminar la propuesta.',
+          'error',
+        );
+      }
+    },
   });
 }
 

--- a/frontend/pages/proposal/[uuid]/index.vue
+++ b/frontend/pages/proposal/[uuid]/index.vue
@@ -80,6 +80,7 @@
           :visitedPanelIds="visitedPanelIds"
           :viewMode="viewMode"
           :language="pLang"
+          :bannerActive="isExpired"
           @navigate="handleNavigate"
           @update:open="(val) => indexOpen = val"
           @switchToDetailed="handleSwitchToDetailed"

--- a/frontend/stores/proposals.js
+++ b/frontend/stores/proposals.js
@@ -283,7 +283,13 @@ export const useProposalStore = defineStore('proposals', {
       } catch (error) {
         this.error = 'delete_failed';
         console.error('Error deleting proposal:', error);
-        return { success: false };
+        return {
+          success: false,
+          error:
+            error.response?.data?.error ||
+            error.response?.data?.detail ||
+            null,
+        };
       /* c8 ignore next 3 */
       } finally {
         this.isUpdating = false;

--- a/frontend/test/components/ProposalIndex.test.js
+++ b/frontend/test/components/ProposalIndex.test.js
@@ -28,6 +28,22 @@ describe('ProposalIndex', () => {
     expect(wrapper.text()).toContain('Presupuesto');
   });
 
+  it('keeps the toggle at top-4 when no banner is active', () => {
+    const wrapper = mountIndex({ bannerActive: false });
+    const toggle = wrapper.find('[data-testid="index-toggle"]');
+
+    expect(toggle.classes()).toContain('top-4');
+  });
+
+  it('drops the toggle below the banner when bannerActive is true', () => {
+    const wrapper = mountIndex({ bannerActive: true });
+    const toggle = wrapper.find('[data-testid="index-toggle"]');
+
+    expect(toggle.classes()).toContain('top-28');
+    expect(toggle.classes()).toContain('sm:top-20');
+    expect(toggle.classes()).not.toContain('top-4');
+  });
+
   it('emits navigate with the section index when a section button is clicked', async () => {
     const wrapper = mountIndex();
 

--- a/frontend/test/stores/proposals.test.js
+++ b/frontend/test/stores/proposals.test.js
@@ -544,6 +544,20 @@ describe('useProposalStore', () => {
 
       expect(store.error).toBe('delete_failed');
     });
+
+    it('propagates backend error message and keeps the proposal', async () => {
+      store.proposals = [{ id: 1 }, { id: 2 }];
+      delete_request.mockRejectedValue({
+        response: { status: 409, data: { error: 'Vinculada a un proyecto' } },
+      });
+
+      const result = await store.deleteProposal(1);
+
+      expect(result.success).toBe(false);
+      expect(result.error).toBe('Vinculada a un proyecto');
+      // List untouched because the delete failed.
+      expect(store.proposals).toEqual([{ id: 1 }, { id: 2 }]);
+    });
   });
 
   describe('sendProposal', () => {


### PR DESCRIPTION
## Resumen

Arregla cinco problemas reportados alrededor de las propuestas.

### 1. Borrado de propuestas (no funcionaba en ninguna vista)
Causa raíz: `ProjectPhase.business_proposal` es `on_delete=PROTECT`, así que borrar una propuesta lanzada a la plataforma lanzaba `ProtectedError` → 500, y el store lo tragaba.
- `delete_proposal` ahora devuelve **409** con mensaje claro listando el proyecto/fases vinculadas.
- Store propaga el mensaje del backend.
- `/panel/proposals`: modal de confirmación (escribir `DELETE`) + `await` + refresh + toast.
- `/panel/clients`: manejo de error con `PanelToast`.

### 2. Botón actualizar no reflejaba renombrar/reasignar
Causa raíz: `loadClients()` no invalidaba `detailCache`, dejando las propuestas expandidas obsoletas. La reasignación sí persiste en backend (`client_id` → FK `client`).
- Nuevo `refreshAll()` que limpia `detailCache` y refetch de clientes expandidos.

### 3. Notificaciones de apertura de más
- Helper `ProposalService.open_notifications_suppressed()` (status `accepted`/`finished`).
- Aplicado en el gate de first-view, en el trigger de stakeholder-detection (el que re-notificaba propuestas viejas por sesión nueva), y defensa en profundidad en la task Huey y el email service. El guard de staff logueado ya existía.

### 4. Banner expirado se superponía al botón de índice (vista pública)
- `ProposalIndex` recibe `bannerActive`; con banner el toggle baja a `top-28 sm:top-20`.

### 5. No llegan notificaciones a clientes reales
- Comando `diagnose_proposal_notifications` (Huey/SMTP/plantillas/recipients, con `--send`). **Correr en prod** para confirmar la causa (en dev las credenciales SMTP están vacías, se setean por env en prod).

## Test plan
- Backend: `pytest content/tests/views/test_proposal_delete.py content/tests/test_open_notification_suppression.py` → 12 passed.
- Frontend unit: `proposals.test.js` + `ProposalIndex.test.js` → 208 passed; `PanelClientsIndex.test.js` → 3 passed.
- `manage.py check` → 0 issues. design-tokens → OK.
- E2E audit (`e2e-user-flows-check`): registrado flujo nuevo `admin-proposal-delete-from-client` + known-gaps en `admin-proposal-delete`, `admin-mini-crm-clients`, `proposal-expired-graceful`.

## Pendiente (depende de prod)
- `python manage.py diagnose_proposal_notifications --send --to <email>` en producción para cerrar el #5 (probable: worker Huey caído o credenciales SMTP).