### PR TITLE
FEAT: preselect branding module, drop Telegram, rename dark-mode module, fix hosting tiers/renewal on all proposals

### DIFF
--- a/.claude/skills/proposal-create/SKILL.md
+++ b/.claude/skills/proposal-create/SKILL.md
@@ -121,7 +121,7 @@ scaffold, decidir si los requerimientos describen esa capacidad. Mapa de detecci
 | PWA, app instalable, offline, push notifications | `pwa_module` |
 | IA, chatbot, asistentes, automatización inteligente | `ai_module` |
 | Meta/Facebook Ads, Google Ads, CAPI, ROAS, Enhanced Conversions | `integration_conversion_tracking` |
-| Reportes/alertas por email/WhatsApp/Telegram, alertas de ventas/stock | `reports_alerts_module` |
+| Reportes/alertas por email/WhatsApp, alertas de ventas/stock | `reports_alerts_module` |
 | Email marketing, Mailchimp, Brevo, SendGrid, captura de leads | `email_marketing_module` |
 | Multi-idioma, i18n, varios países, precios por país | `i18n_module` |
 | Chat en vivo, soporte en tiempo real | `live_chat_module` |

--- a/backend/content/management/commands/refresh_proposal_default_config.py
+++ b/backend/content/management/commands/refresh_proposal_default_config.py
@@ -1,0 +1,162 @@
+"""Surgically patch ProposalDefaultConfig.sections_json from code DEFAULT_SECTIONS.
+
+The DB-backed ``ProposalDefaultConfig.sections_json`` is the live template that
+seeds every new proposal (``get_default_sections``). It is an old snapshot of the
+code ``DEFAULT_SECTIONS`` / ``DEFAULT_SECTIONS_EN`` and has drifted. Rather than
+overwriting the whole snapshot (which would also revert unrelated sections that
+have merely evolved in code), this command patches ONLY the fields this change
+cares about, copying their current values from code:
+
+  - investment.hostingPlan.billingTiers   (annual/semiannual/quarterly, no monthly)
+  - investment.hostingPlan.renewalNote     (new SMLMV + 8% formula)
+  - corporate_branding_module.selected / default_selected = True
+  - reports_alerts_module.title/description/items          (Telegram removed)
+  - dark_mode_module.title/description                     (renamed)
+
+Everything else in sections_json is left untouched.
+
+Usage:
+    python manage.py refresh_proposal_default_config            # dry-run
+    python manage.py refresh_proposal_default_config --apply    # writes + backup
+    python manage.py refresh_proposal_default_config --language es --apply
+"""
+import copy
+import json
+import os
+
+from django.core.management.base import BaseCommand
+
+from content.models import ProposalDefaultConfig
+from content.services.proposal_service import (
+    DEFAULT_SECTIONS,
+    DEFAULT_SECTIONS_EN,
+)
+
+PATCHED_MODULE_IDS = (
+    'corporate_branding_module',
+    'reports_alerts_module',
+    'dark_mode_module',
+)
+
+
+def _code_sections(language):
+    source = DEFAULT_SECTIONS_EN if language == 'en' else DEFAULT_SECTIONS
+    return copy.deepcopy(source)
+
+
+def _section(sections, section_type):
+    for s in (sections or []):
+        if isinstance(s, dict) and s.get('section_type') == section_type:
+            return s
+    return None
+
+
+def _module(section, module_id):
+    cj = (section or {}).get('content_json') or {}
+    for arr in ('groups', 'additionalModules'):
+        for g in (cj.get(arr) or []):
+            if isinstance(g, dict) and g.get('id') == module_id:
+                return g
+    return None
+
+
+def _patch(sections, code):
+    """Mutate *sections* in place with the targeted fields from *code*.
+
+    Returns a list of human-readable change descriptions.
+    """
+    changes = []
+
+    # --- investment hosting plan ---
+    inv, code_inv = _section(sections, 'investment'), _section(code, 'investment')
+    hp = (inv or {}).get('content_json', {}).get('hostingPlan') if inv else None
+    code_hp = (code_inv or {}).get('content_json', {}).get('hostingPlan') if code_inv else None
+    if isinstance(hp, dict) and isinstance(code_hp, dict):
+        old_tiers = [t.get('frequency') for t in (hp.get('billingTiers') or [])
+                     if isinstance(t, dict)]
+        new_tiers = copy.deepcopy(code_hp.get('billingTiers') or [])
+        if hp.get('billingTiers') != new_tiers:
+            hp['billingTiers'] = new_tiers
+            changes.append(
+                f"hosting billingTiers {old_tiers} -> "
+                f"{[t.get('frequency') for t in new_tiers]}")
+        if 'renewalNote' in code_hp and hp.get('renewalNote') != code_hp['renewalNote']:
+            hp['renewalNote'] = code_hp['renewalNote']
+            changes.append('hosting renewalNote -> new SMLMV+8% formula')
+        if 'coverageNote' in code_hp and hp.get('coverageNote') != code_hp['coverageNote']:
+            hp['coverageNote'] = code_hp['coverageNote']
+            changes.append('hosting coverageNote -> code')
+
+    # --- functional_requirements modules ---
+    fr = _section(sections, 'functional_requirements')
+    code_fr = _section(code, 'functional_requirements')
+    for mid in PATCHED_MODULE_IDS:
+        g, code_g = _module(fr, mid), _module(code_fr, mid)
+        if not isinstance(g, dict) or not isinstance(code_g, dict):
+            continue
+        if mid == 'corporate_branding_module':
+            if not (g.get('selected') and g.get('default_selected')):
+                g['selected'] = True
+                g['default_selected'] = True
+                changes.append(f'{mid}.selected -> True')
+        else:
+            for field in ('title', 'description', 'items'):
+                if field in code_g and g.get(field) != code_g[field]:
+                    g[field] = copy.deepcopy(code_g[field])
+                    changes.append(f'{mid}.{field} -> code')
+    return changes
+
+
+class Command(BaseCommand):
+    help = 'Surgically patch ProposalDefaultConfig.sections_json from code defaults.'
+
+    def add_arguments(self, parser):
+        parser.add_argument('--apply', action='store_true',
+                            help='Write the changes (default: dry-run).')
+        parser.add_argument('--language', choices=['es', 'en'], default=None,
+                            help='Only this language (default: all configs).')
+        parser.add_argument('--backup-dir', default=None,
+                            help='Directory for JSON backups (default: cwd).')
+
+    def handle(self, *args, **opts):
+        apply = opts['apply']
+        backup_dir = opts['backup_dir'] or os.getcwd()
+        qs = ProposalDefaultConfig.objects.all()
+        if opts['language']:
+            qs = qs.filter(language=opts['language'])
+
+        if not qs.exists():
+            self.stdout.write('No ProposalDefaultConfig rows found. '
+                              'New proposals already use code DEFAULT_SECTIONS.')
+            return
+
+        for config in qs:
+            lang = config.language
+            current = copy.deepcopy(config.sections_json or [])
+            code = _code_sections(lang)
+            changes = _patch(current, code)
+
+            self.stdout.write(self.style.MIGRATE_HEADING(
+                f'\n=== config language={lang} ==='))
+            if not changes:
+                self.stdout.write('  already up to date — nothing to patch.')
+                continue
+            for c in changes:
+                self.stdout.write(f'  • {c}')
+
+            if not apply:
+                continue
+
+            backup_path = os.path.join(
+                backup_dir, f'proposal_default_config_{lang}.backup.json')
+            with open(backup_path, 'w', encoding='utf-8') as fh:
+                json.dump(config.sections_json or [], fh,
+                          ensure_ascii=False, indent=2)
+            config.sections_json = current
+            config.save(update_fields=['sections_json'])
+            self.stdout.write(self.style.SUCCESS(
+                f'  ✅ applied {len(changes)} change(s). backup -> {backup_path}'))
+
+        if not apply:
+            self.stdout.write(self.style.WARNING(
+                '\nDry-run only. Re-run with --apply to write the changes.'))

--- a/backend/content/migrations/0126_fix_legacy_renewal_note.py
+++ b/backend/content/migrations/0126_fix_legacy_renewal_note.py
@@ -1,0 +1,75 @@
+"""Rewrite the legacy hosting renewal note on existing proposals.
+
+Older proposals (and the previous default-config snapshot) stored a renewal note
+with the OLD additive formula: ``Costo anterior + (6% × SMLMV)``. The offered
+terms are now the multiplicative ``× (1 + (Δ%SMLMV + 8%))`` formula. This data
+migration replaces the stored note ONLY when it clearly matches the old default
+(mentions ``6%`` and ``SMLMV`` but not ``8%``), so genuinely customized notes are
+left untouched. New proposals already get the new note from the refreshed config.
+"""
+from django.db import migrations
+
+
+RENEWAL_ES = (
+    'Renovaciones para cada año de renovación (a partir del segundo año): '
+    'el costo se ajusta una vez al año tomando como referencia el porcentaje '
+    'en que aumentó el SMLMV (Salario Mínimo Legal Mensual Vigente en Colombia) '
+    'ese año, más un 8% fijo, aplicado sobre el costo del año anterior:\n\n'
+    'Costo de renovación = Costo del año anterior × '
+    '(1 + (% de aumento del SMLMV + 8%))\n\n'
+    'Por ejemplo, si el SMLMV aumentó 5%, el incremento total sería '
+    '5% + 8% = 13%. Si venías pagando $100.000 COP, el nuevo costo sería '
+    '$113.000 COP (un aumento de $13.000).'
+)
+
+RENEWAL_EN = (
+    'Renewals for each renewal year (from the second year onward): the cost '
+    'is adjusted once a year based on the percentage by which the SMLMV '
+    "(Colombia's monthly legal minimum wage) increased that year, plus a "
+    "fixed 8%, applied to the previous year's cost:\n\n"
+    'Renewal cost = Previous year cost × (1 + (SMLMV increase % + 8%))\n\n'
+    'For example, if the SMLMV increased 5%, the total increase would be '
+    '5% + 8% = 13%. If you were paying $100,000 COP, the new cost would be '
+    '$113,000 COP (a $13,000 increase).'
+)
+
+
+def _is_legacy(note):
+    if not isinstance(note, str) or not note:
+        return False
+    low = note.lower()
+    return ('6%' in note and '8%' not in note
+            and ('smlmv' in low or 'minimum wage' in low))
+
+
+def fix_renewal_notes(apps, schema_editor):
+    ProposalSection = apps.get_model('content', 'ProposalSection')
+    qs = ProposalSection.objects.filter(section_type='investment')
+    for section in qs.iterator():
+        cj = section.content_json
+        if not isinstance(cj, dict):
+            continue
+        hp = cj.get('hostingPlan')
+        if not isinstance(hp, dict):
+            continue
+        if not _is_legacy(hp.get('renewalNote')):
+            continue
+        lang = getattr(getattr(section, 'proposal', None), 'language', 'es') or 'es'
+        hp['renewalNote'] = RENEWAL_EN if lang == 'en' else RENEWAL_ES
+        section.content_json = cj
+        section.save(update_fields=['content_json'])
+
+
+def noop_reverse(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('content', '0125_businessproposal_hosting_discount_annual'),
+    ]
+
+    operations = [
+        migrations.RunPython(fix_renewal_notes, noop_reverse),
+    ]

--- a/backend/content/services/proposal_service.py
+++ b/backend/content/services/proposal_service.py
@@ -658,8 +658,8 @@ DEFAULT_SECTIONS = [
                         'marca se perciba profesional y coherente en todo lugar donde tus clientes interactúan.'
                     ),
                     'is_calculator_module': True,
-                    'default_selected': False,
-                    'selected': False,
+                    'default_selected': True,
+                    'selected': True,
                     'price_percent': 35,
                     'items': [
                         {'icon': '✉️', 'name': 'Correos transaccionales con identidad corporativa', 'description': 'Plantillas HTML con logo, colores, tipografía y firma de marca aplicadas en todos los correos del sistema — bienvenida, confirmaciones, alertas, recuperación de contraseña y notificaciones — en lugar de correos en texto plano o genéricos.'},
@@ -769,11 +769,11 @@ DEFAULT_SECTIONS = [
                 {
                     'id': 'reports_alerts_module',
                     'icon': '📬',
-                    'title': 'Reportes y Alertas vía Correo, WhatsApp o Telegram',
+                    'title': 'Reportes y Alertas vía Correo o WhatsApp',
                     'is_visible': True,
                     'description': (
                         'Mantente informado en todo momento con reportes automáticos y alertas '
-                        'personalizadas que llegan directamente a tu correo, WhatsApp o Telegram.'
+                        'personalizadas que llegan directamente a tu correo o WhatsApp.'
                     ),
                     'is_calculator_module': True,
                     'default_selected': False,
@@ -783,7 +783,6 @@ DEFAULT_SECTIONS = [
                         {'icon': '📧', 'name': 'Reportes automáticos por correo', 'description': 'Recibe resúmenes periódicos con las métricas clave de tu negocio directamente en tu bandeja de entrada, sin tener que entrar al sistema.'},
                         {'icon': '🔔', 'name': 'Alertas personalizadas', 'description': 'Configura notificaciones para eventos importantes: nuevas ventas, registros de usuarios, stock bajo, o cualquier métrica que definas.'},
                         {'icon': '💚', 'name': 'Integración con WhatsApp', 'description': 'Recibe alertas y reportes instantáneos en tu número de WhatsApp a través de la API oficial, ideal para estar al tanto desde el mismo canal donde atiendes a tus clientes.'},
-                        {'icon': '✈️', 'name': 'Integración con Telegram', 'description': 'Recibe alertas y reportes instantáneos en tu chat de Telegram, ideal para estar al tanto desde cualquier lugar y en tiempo real.'},
                         {'icon': '⏰', 'name': 'Programación de envíos', 'description': 'Define la frecuencia y horario de tus reportes: diario, semanal, mensual o en tiempo real según tus necesidades.'},
                         {'icon': '📋', 'name': 'Resumen ejecutivo periódico', 'description': 'Informe consolidado con las métricas más relevantes de tu proyecto, diseñado para una lectura rápida y toma de decisiones ágil.'},
                     ],
@@ -911,13 +910,12 @@ DEFAULT_SECTIONS = [
                 {
                     'id': 'dark_mode_module',
                     'icon': '🌙',
-                    'title': 'Motor de Tematización Dinámica (Dark Mode)',
+                    'title': 'Modo Oscuro y Claro',
                     'is_visible': True,
                     'description': (
-                        'Soporte técnico nativo que respeta las preferencias del sistema operativo '
-                        'del usuario, alternando fluidamente entre modo claro y oscuro con persistencia '
-                        'de elección. Un requerimiento visual contemporáneo que reduce la fatiga visual '
-                        'y proyecta modernidad absoluta.'
+                        'El sistema alterna automáticamente entre modo claro y oscuro según la '
+                        'preferencia del dispositivo del usuario, y recuerda su elección. Reduce la '
+                        'fatiga visual y le da un acabado moderno a la plataforma.'
                     ),
                     'is_calculator_module': True,
                     'default_selected': False,
@@ -1862,8 +1860,8 @@ DEFAULT_SECTIONS_EN = [
                         'coherent everywhere your customers interact with it.'
                     ),
                     'is_calculator_module': True,
-                    'default_selected': False,
-                    'selected': False,
+                    'default_selected': True,
+                    'selected': True,
                     'price_percent': 35,
                     'items': [
                         {'icon': '✉️', 'name': 'Branded Transactional Emails', 'description': 'HTML templates with logo, colors, typography and brand signature applied across all system emails — welcome, confirmations, alerts, password recovery and notifications — instead of plain-text or generic messages.'},
@@ -1972,11 +1970,11 @@ DEFAULT_SECTIONS_EN = [
                 {
                     'id': 'reports_alerts_module',
                     'icon': '📬',
-                    'title': 'Reports & Alerts via Email, WhatsApp or Telegram',
+                    'title': 'Reports & Alerts via Email or WhatsApp',
                     'is_visible': True,
                     'description': (
                         'Stay informed at all times with automated reports and customized alerts '
-                        'delivered directly to your email, WhatsApp or Telegram.'
+                        'delivered directly to your email or WhatsApp.'
                     ),
                     'is_calculator_module': True,
                     'default_selected': False,
@@ -1986,7 +1984,6 @@ DEFAULT_SECTIONS_EN = [
                         {'icon': '📧', 'name': 'Automated Email Reports', 'description': 'Receive periodic summaries with key business metrics directly in your inbox, without having to log into the system.'},
                         {'icon': '🔔', 'name': 'Custom Alerts', 'description': 'Set up notifications for important events: new sales, user registrations, low stock, or any metric you define.'},
                         {'icon': '💚', 'name': 'WhatsApp Integration', 'description': 'Receive instant alerts and reports on your WhatsApp number through the official API, perfect for staying informed from the same channel where you serve your customers.'},
-                        {'icon': '✈️', 'name': 'Telegram Integration', 'description': 'Receive instant alerts and reports in your Telegram chat, perfect for staying informed from anywhere in real time.'},
                         {'icon': '⏰', 'name': 'Scheduled Delivery', 'description': 'Define the frequency and timing of your reports: daily, weekly, monthly, or real-time based on your needs.'},
                         {'icon': '📋', 'name': 'Periodic Executive Summary', 'description': 'Consolidated report with the most relevant metrics of your project, designed for quick reading and agile decision-making.'},
                     ],
@@ -2112,13 +2109,12 @@ DEFAULT_SECTIONS_EN = [
                 },                {
                     'id': 'dark_mode_module',
                     'icon': '🌙',
-                    'title': 'Dynamic Theming Engine (Dark Mode)',
+                    'title': 'Dark & Light Mode',
                     'is_visible': True,
                     'description': (
-                        'Native technical support that respects the user\'s operating system preferences, '
-                        'seamlessly switching between light and dark mode with choice persistence. '
-                        'A contemporary visual requirement that reduces eye strain '
-                        'and projects absolute modernity.'
+                        'The system automatically switches between light and dark mode based on the '
+                        'user\'s device preference, and remembers their choice. It reduces eye strain '
+                        'and gives the platform a modern finish.'
                     ),
                     'is_calculator_module': True,
                     'default_selected': False,
@@ -2457,16 +2453,64 @@ def normalize_hosting_plan(proposal, hosting_plan_json):
         HostingSubscription.PLAN_QUARTERLY:
             getattr(proposal, 'hosting_discount_quarterly', None),
     }
+
+    # Enforce the canonical set of *offered* payment tiers, best-discount first.
+    # Month-to-month is no longer offered, so any stored 'monthly' tier is
+    # dropped, and the annual tier is guaranteed even for older proposals whose
+    # stored content predates it. Stored label/badge/months are preserved when
+    # present; discounts always come from the model fields. This keeps the public
+    # view and the PDF consistent for every proposal regardless of stored drift.
+    lang = getattr(proposal, 'language', 'es') or 'es'
+    stored_by_freq = {
+        t.get('frequency'): t
+        for t in (base.get('billingTiers') or [])
+        if isinstance(t, dict)
+    }
+    # No stored tiers → leave empty; the frontend falls back to its own default
+    # tier list. Only reconcile to the canonical set when tiers actually exist.
+    if not stored_by_freq:
+        base['billingTiers'] = []
+        return base
+    tier_defaults = {
+        HostingSubscription.PLAN_ANNUAL: {
+            'months': 12,
+            'label': 'Annual' if lang == 'en' else 'Anual',
+            'badge': 'Best value' if lang == 'en' else 'Máximo descuento',
+            'discount': 40,
+        },
+        HostingSubscription.PLAN_SEMIANNUAL: {
+            'months': 6,
+            'label': 'Semiannual' if lang == 'en' else 'Semestral',
+            'badge': '20% off' if lang == 'en' else '20% dcto',
+            'discount': 20,
+        },
+        HostingSubscription.PLAN_QUARTERLY: {
+            'months': 3,
+            'label': 'Quarterly' if lang == 'en' else 'Trimestral',
+            'badge': '10% off' if lang == 'en' else '10% dcto',
+            'discount': 10,
+        },
+    }
     normalized_tiers = []
-    for tier in base.get('billingTiers', []) or []:
-        if not isinstance(tier, dict):
-            continue
-        override = discount_overrides.get(tier.get('frequency'))
-        discount = (
-            override if override is not None
-            else tier.get('discountPercent', 0)
-        )
-        normalized_tiers.append({**tier, 'discountPercent': discount})
+    for freq in (HostingSubscription.PLAN_ANNUAL,
+                 HostingSubscription.PLAN_SEMIANNUAL,
+                 HostingSubscription.PLAN_QUARTERLY):
+        defaults = tier_defaults[freq]
+        stored = stored_by_freq.get(freq) or {}
+        override = discount_overrides.get(freq)
+        if override is not None:
+            discount = override
+        elif stored.get('discountPercent') is not None:
+            discount = stored.get('discountPercent')
+        else:
+            discount = defaults['discount']
+        normalized_tiers.append({
+            'frequency': freq,
+            'months': stored.get('months', defaults['months']),
+            'label': stored.get('label') or defaults['label'],
+            'badge': stored.get('badge', defaults['badge']),
+            'discountPercent': discount,
+        })
     base['billingTiers'] = normalized_tiers
     return base
 

--- a/backend/content/tests/serializers/test_proposal_serializers.py
+++ b/backend/content/tests/serializers/test_proposal_serializers.py
@@ -938,7 +938,10 @@ class TestProposalSectionDetailSerializerHostingNormalization:
                      for t in plan['billingTiers']}
         assert discounts['semiannual'] == 22
         assert discounts['quarterly'] == 11
-        assert discounts['monthly'] == 0
+        # Monthly is no longer an offered tier; the annual tier is guaranteed
+        # (taking its discount from the model default).
+        assert 'monthly' not in discounts
+        assert discounts['annual'] == 40
 
     def test_non_investment_section_is_not_mutated(self):
         from content.models import BusinessProposal, ProposalSection

--- a/backend/content/tests/services/test_proposal_pdf_service.py
+++ b/backend/content/tests/services/test_proposal_pdf_service.py
@@ -3098,6 +3098,7 @@ class TestInvestmentHostingModelOverride:
             language='es', currency='COP', status='sent',
             total_investment=Decimal('6000000'),
             hosting_percent=40,
+            hosting_discount_annual=40,
             hosting_discount_semiannual=25,
             hosting_discount_quarterly=15,
         )
@@ -3129,11 +3130,16 @@ class TestInvestmentHostingModelOverride:
         _render_investment(pdf_canvas, data, proposal)
 
         monthly_strings = [t for t in drawn if '/mes' in t]
-        # Model values: 6_000_000 × 40% / 12 = 200_000 monthly base
-        #   semiannual (25%): 150_000, quarterly (15%): 170_000, monthly (0%): 200_000
-        assert any('$200.000' in t for t in monthly_strings), (
-            f'Expected monthly tier $200.000/mes from model hosting_percent=40; '
+        # Model values: 6_000_000 × 40% / 12 = 200_000 monthly base. The offered
+        # tiers are annual/semiannual/quarterly (monthly is no longer offered):
+        #   annual (40%): 120_000, semiannual (25%): 150_000, quarterly (15%): 170_000
+        assert any('$120.000' in t for t in monthly_strings), (
+            f'Expected annual tier $120.000/mes from model discount=40; '
             f'got: {monthly_strings}'
+        )
+        # Monthly is no longer an offered tier.
+        assert not any('$200.000 /mes' in t for t in monthly_strings), (
+            f'Monthly tier should no longer be rendered; got: {monthly_strings}'
         )
         assert any('$170.000' in t for t in monthly_strings), (
             f'Expected quarterly tier $170.000/mes from model discount=15; '

--- a/backend/content/tests/services/test_proposal_service.py
+++ b/backend/content/tests/services/test_proposal_service.py
@@ -280,7 +280,9 @@ class TestGetDefaultSections:
         cb = next(g for g in fr['content_json']['additionalModules'] if g['id'] == 'corporate_branding_module')
         assert len(cb['items']) == 5
         assert cb['is_calculator_module'] is True
-        assert cb['default_selected'] is False
+        # Pre-selected by default for every new proposal.
+        assert cb['default_selected'] is True
+        assert cb['selected'] is True
         assert cb['price_percent'] == 35
         assert cb.get('is_invite', False) is False
         assert cb['is_visible'] is True
@@ -294,17 +296,20 @@ class TestGetDefaultSections:
         assert ai['is_invite'] is True
         assert ai['price_percent'] == 0
 
-    def test_reports_alerts_module_has_6_items_and_default_not_selected(self):
+    def test_reports_alerts_module_has_5_items_and_default_not_selected(self):
         sections = ProposalService.get_default_sections('es')
         fr = next(s for s in sections if s['section_type'] == 'functional_requirements')
         reports = next(g for g in fr['content_json']['additionalModules'] if g['id'] == 'reports_alerts_module')
-        assert len(reports['items']) == 6
+        assert len(reports['items']) == 5
         assert reports['is_calculator_module'] is True
         assert reports['default_selected'] is False
         assert reports['price_percent'] == 20
         assert 'WhatsApp' in reports['title']
+        # Telegram is no longer offered as a notification channel.
+        assert 'Telegram' not in reports['title']
         item_names = [i['name'] for i in reports['items']]
         assert 'Integración con WhatsApp' in item_names
+        assert all('Telegram' not in n for n in item_names)
 
     def test_en_calculator_modules_mirror_es(self):
         """EN additional modules match ES in item count, calculator flag, and price percent."""
@@ -366,11 +371,18 @@ class TestGetDefaultSections:
             assert g['price_percent'] == 0, f"Group {g['id']} should have price_percent=0"
 
     def test_all_additional_modules_have_selected_false(self):
-        """Verify all additional modules have selected=False."""
+        """Verify additional modules default to selected=False.
+
+        Exception: corporate_branding_module is pre-selected by default for
+        every new proposal.
+        """
+        always_selected = {'corporate_branding_module'}
         sections = ProposalService.get_default_sections('es')
         fr = next(s for s in sections if s['section_type'] == 'functional_requirements')
         for g in fr['content_json']['additionalModules']:
-            assert g['selected'] is False, f"Additional module {g['id']} should have selected=False"
+            expected = g['id'] in always_selected
+            assert g['selected'] is expected, (
+                f"Additional module {g['id']} should have selected={expected}")
 
     def test_en_regular_groups_match_es_selected_and_price_percent(self):
         """Verify EN regular groups have same selected and price_percent values as ES."""
@@ -904,7 +916,11 @@ class TestNormalizeHostingPlan:
 
     def _proposal(self, **overrides):
         p = MagicMock()
+        p.language = overrides.get('language', 'es')
         p.hosting_percent = overrides.get('hosting_percent', 40)
+        p.hosting_discount_annual = overrides.get(
+            'hosting_discount_annual', 40,
+        )
         p.hosting_discount_semiannual = overrides.get(
             'hosting_discount_semiannual', 25,
         )
@@ -934,15 +950,21 @@ class TestNormalizeHostingPlan:
         tiers = {t['frequency']: t for t in result['billingTiers']}
         assert tiers['semiannual']['discountPercent'] == 25
         assert tiers['quarterly']['discountPercent'] == 15
+        # Annual is guaranteed even though the input lacked it.
+        assert tiers['annual']['discountPercent'] == 40
+        assert 'monthly' not in tiers
 
-    def test_monthly_tier_discount_untouched(self):
+    def test_monthly_tier_is_dropped_and_annual_guaranteed(self):
+        # A legacy proposal that only stored a monthly tier is reconciled to the
+        # canonical offered set [annual, semiannual, quarterly] with no monthly.
         result = normalize_hosting_plan(
             self._proposal(),
             {'billingTiers': [
                 {'frequency': 'monthly', 'discountPercent': 0, 'months': 1},
             ]},
         )
-        assert result['billingTiers'][0]['discountPercent'] == 0
+        freqs = [t['frequency'] for t in result['billingTiers']]
+        assert freqs == ['annual', 'semiannual', 'quarterly']
 
     def test_missing_model_percent_falls_back_to_json(self):
         p = self._proposal(hosting_percent=0)
@@ -967,8 +989,9 @@ class TestNormalizeHostingPlan:
                 {'frequency': 'monthly', 'months': 1, 'discountPercent': 0},
             ]},
         )
-        assert len(result['billingTiers']) == 1
-        assert result['billingTiers'][0]['frequency'] == 'monthly'
+        # Malformed entries are ignored; the result is the canonical offered set.
+        freqs = [t['frequency'] for t in result['billingTiers']]
+        assert freqs == ['annual', 'semiannual', 'quarterly']
 
     def test_none_billing_tiers_returns_empty_list(self):
         result = normalize_hosting_plan(

--- a/backend/content/views/proposal.py
+++ b/backend/content/views/proposal.py
@@ -1379,7 +1379,7 @@ def get_proposal_json_template(request):
             'notifications -> "pwa_module". AI, intelligent automation, chatbot, assistants '
             '-> "ai_module". Meta Ads, Facebook Ads, Google Ads, Conversions API, CAPI, ROAS, '
             'Enhanced Conversions -> "integration_conversion_tracking". Reports, notifications '
-            'or alerts via email/WhatsApp/Telegram, sales/stock alerts -> '
+            'or alerts via email/WhatsApp, sales/stock alerts -> '
             '"reports_alerts_module". Email marketing, Mailchimp, Brevo, SendGrid, lead '
             'capture -> "email_marketing_module". Multi-language, i18n, multiple countries, '
             'translations, per-country pricing -> "i18n_module". Live chat, real-time '

--- a/frontend/composables/useSellerPrompt.js
+++ b/frontend/composables/useSellerPrompt.js
@@ -368,7 +368,7 @@ Sección de presentación que **agrupa los 4 módulos base sin costo extra** (ad
     - \`pwa_module\` → PWA, app instalable, funciona sin internet, modo offline, notificaciones push.
     - \`ai_module\` → IA, inteligencia artificial, chatbot inteligente, automatización con IA, agentes.
     - \`integration_conversion_tracking\` → Meta Ads, Facebook Ads, Google Ads, Conversions API, CAPI, ROAS, pixel, Enhanced Conversions.
-    - \`reports_alerts_module\` → reportes, notificaciones, alertas por correo / WhatsApp / Telegram, avisos de ventas o stock.
+    - \`reports_alerts_module\` → reportes, notificaciones, alertas por correo / WhatsApp, avisos de ventas o stock.
     - \`email_marketing_module\` → email marketing, Mailchimp, Brevo, SendGrid, captura de leads, newsletters.
     - \`i18n_module\` → multi-idioma, internacionalización, i18n, múltiples países, traducción, catálogos por país.
     - \`live_chat_module\` → chat en vivo, soporte en tiempo real, asesor en línea, widget de chat propio.

--- a/frontend/e2e/proposal/proposal-calculator-modules.spec.js
+++ b/frontend/e2e/proposal/proposal-calculator-modules.spec.js
@@ -111,7 +111,7 @@ const mockProposal = {
           {
             id: 'reports_alerts_module',
             icon: '📬',
-            title: 'Reportes y Alertas vía Correo o Telegram',
+            title: 'Reportes y Alertas vía Correo o WhatsApp',
             is_visible: true,
             description: 'Reportes automáticos y alertas personalizadas.',
             is_calculator_module: true,
@@ -119,7 +119,7 @@ const mockProposal = {
             price_percent: 20,
             items: [
               { icon: '📧', name: 'Reportes automáticos', description: 'Métricas por correo.' },
-              { icon: '✈️', name: 'Integración con Telegram', description: 'Alertas en Telegram.' },
+              { icon: '💚', name: 'Integración con WhatsApp', description: 'Alertas en WhatsApp.' },
             ],
           },
         ],


### PR DESCRIPTION
## Root cause
`ProposalDefaultConfig.sections_json` (DB) is the live template for new proposals and is a **stale snapshot** — so code `DEFAULT_SECTIONS` edits never reached new proposals, and existing proposals keep stale `content_json`. This explains why hosting tiers (monthly) and the renewal formula (6%) kept showing despite earlier code changes.

## Changes
- **Identidad Visual** (`corporate_branding_module`) now `selected`/`default_selected` by default (es+en).
- **Telegram removed** from `reports_alerts_module` (title/description/items → Email + WhatsApp only), and from the seller prompts, the calculator E2E fixture, and `proposal-create` SKILL.md.
- **Dark-mode module renamed** "Motor de Tematización Dinámica" → **"Modo Oscuro y Claro"** / "Dynamic Theming Engine" → **"Dark & Light Mode"**, with simpler copy.
- **`normalize_hosting_plan` enforces the canonical offered tier set** `[annual, semiannual, quarterly]` at render time (drops legacy `monthly`, guarantees `annual`, model discounts as source of truth) → fixes the **public view AND PDF for every proposal**, old or new, with no data surgery.
- **`refresh_proposal_default_config`** management command: surgically patches the DB config's `sections_json` from code (dry-run default; `--apply` writes a JSON backup first; leaves all other sections untouched).
- **Migration `0126`**: rewrites the legacy renewal note (`+ (6% × SMLMV)`) on existing proposals to the new `× (1 + (Δ%SMLMV + 8%))` note, matched by pattern so custom notes are preserved.

## Scope decisions
- Branding / theme / Telegram → **new proposals** (source: code + config refresh).
- Hosting tiers + renewal → **all proposals** (render-time normalize + migration).
- Biometric module pricing → per-proposal data edit (`price_percent`) pending the intended %.

## Test plan (sqlite-isolated)
- `test_proposal_service.py` (95), serializer normalization, effective-total + backfill — green.
- normalize tests assert the canonical set (no monthly, annual guaranteed).
- refresh command dry-run against prod shows only the 8 targeted patches (no unrelated sections touched).
- migration `0126` `_is_legacy` heuristic verified (old→True, new/custom→False).
- frontend: `useSellerPrompt` + `InvestmentCalculatorModal` + `ProposalDefaultsPanel` (132).

## Deploy steps (post-merge)
1. `migrate` (runs `0126` — rewrites legacy renewal notes).
2. `python manage.py refresh_proposal_default_config` (review dry-run diff) then `--apply`.
3. Rebuild frontend (embeds updated seller prompt) + restart.