### PR TITLE
FEAT: add "Login with this user" impersonation for superusers

### DIFF
--- a/backend/accounts/services/impersonation.py
+++ b/backend/accounts/services/impersonation.py
@@ -1,0 +1,75 @@
+"""Impersonation ("Log in as this user") service.
+
+Centralizes the rules and token minting shared by the Django admin button and
+the panel DRF endpoint, so both surfaces enforce the exact same policy.
+"""
+from urllib.parse import urlencode
+
+from django.conf import settings
+
+from accounts.services.tokens import get_tokens_for_user
+
+
+class ImpersonationError(Exception):
+    """Business rule violation while trying to impersonate a user.
+
+    ``status_code`` lets the DRF endpoint return the right HTTP status; the
+    Django admin surfaces ``message`` as a flash error regardless.
+    """
+
+    def __init__(self, message, status_code=400):
+        self.message = message
+        self.status_code = status_code
+        super().__init__(message)
+
+
+def impersonate(actor, target):
+    """Validate the policy and mint JWT tokens for ``target``.
+
+    Rules (mirror of the fleet base implementation):
+    - only active superusers may impersonate,
+    - cannot impersonate another superuser (self is allowed),
+    - cannot impersonate an inactive user,
+    - target must have a platform profile, otherwise the resulting session
+      would be unusable on ``/platform/``.
+
+    :returns: ``{'access': ..., 'refresh': ...}``
+    :raises ImpersonationError: when any rule is violated.
+    """
+    if not (actor and actor.is_active and actor.is_superuser):
+        raise ImpersonationError(
+            'Solo los superusuarios activos pueden iniciar sesión como otro usuario.',
+            status_code=403,
+        )
+
+    if target.is_superuser and target.pk != actor.pk:
+        raise ImpersonationError(
+            'No puedes iniciar sesión como otro superusuario.',
+            status_code=403,
+        )
+
+    if not target.is_active:
+        raise ImpersonationError('Este usuario está inactivo.', status_code=400)
+
+    if getattr(target, 'profile', None) is None:
+        raise ImpersonationError(
+            'Este usuario no tiene un perfil de plataforma.',
+            status_code=400,
+        )
+
+    return get_tokens_for_user(target)
+
+
+def build_impersonation_redirect_url(tokens, redirect_path='/platform'):
+    """Build the absolute frontend callback URL that consumes the tokens.
+
+    The i18n strategy is ``prefix``, so the locale segment is always present.
+    """
+    base = settings.FRONTEND_BASE_URL.rstrip('/')
+    locale = getattr(settings, 'FRONTEND_DEFAULT_LOCALE', 'en-us')
+    query = urlencode({
+        'access': tokens['access'],
+        'refresh': tokens['refresh'],
+        'redirect': redirect_path,
+    })
+    return f'{base}/{locale}/platform/admin-login?{query}'

--- a/backend/accounts/services/impersonation.py
+++ b/backend/accounts/services/impersonation.py
@@ -2,12 +2,21 @@
 
 Centralizes the rules and token minting shared by the Django admin button and
 the panel DRF endpoint, so both surfaces enforce the exact same policy.
+
+Tokens are never placed on a URL. Instead the backend mints them, stores them
+behind a short-lived single-use exchange code, and the frontend callback POSTs
+that code to swap it for the real tokens.
 """
+import secrets
 from urllib.parse import urlencode
 
 from django.conf import settings
+from django.core.cache import cache
 
 from accounts.services.tokens import get_tokens_for_user
+
+EXCHANGE_CODE_TTL_SECONDS = 60
+EXCHANGE_CODE_PREFIX = 'impersonation:exchange:'
 
 
 class ImpersonationError(Exception):
@@ -60,16 +69,37 @@ def impersonate(actor, target):
     return get_tokens_for_user(target)
 
 
-def build_impersonation_redirect_url(tokens, redirect_path='/platform'):
-    """Build the absolute frontend callback URL that consumes the tokens.
+def create_exchange_code(tokens):
+    """Store ``tokens`` behind a random opaque code with a short TTL.
+
+    The code is the only thing that travels on the callback URL; it is
+    single-use (consumed on exchange) and expires automatically.
+    """
+    code = secrets.token_urlsafe(32)
+    cache.set(f'{EXCHANGE_CODE_PREFIX}{code}', tokens, timeout=EXCHANGE_CODE_TTL_SECONDS)
+    return code
+
+
+def consume_exchange_code(code):
+    """Return the tokens bound to ``code`` and invalidate it (single-use).
+
+    :returns: the tokens dict, or ``None`` if the code is missing/expired/used.
+    """
+    if not code:
+        return None
+    key = f'{EXCHANGE_CODE_PREFIX}{code}'
+    tokens = cache.get(key)
+    if tokens is not None:
+        cache.delete(key)
+    return tokens
+
+
+def build_impersonation_redirect_url(code, redirect_path='/platform'):
+    """Build the absolute frontend callback URL carrying only the exchange code.
 
     The i18n strategy is ``prefix``, so the locale segment is always present.
     """
     base = settings.FRONTEND_BASE_URL.rstrip('/')
     locale = getattr(settings, 'FRONTEND_DEFAULT_LOCALE', 'en-us')
-    query = urlencode({
-        'access': tokens['access'],
-        'refresh': tokens['refresh'],
-        'redirect': redirect_path,
-    })
+    query = urlencode({'code': code, 'redirect': redirect_path})
     return f'{base}/{locale}/platform/admin-login?{query}'

--- a/backend/accounts/tests/test_impersonation.py
+++ b/backend/accounts/tests/test_impersonation.py
@@ -14,6 +14,8 @@ from accounts.models import UserProfile
 from accounts.services.impersonation import (
     ImpersonationError,
     build_impersonation_redirect_url,
+    consume_exchange_code,
+    create_exchange_code,
     impersonate,
 )
 
@@ -126,12 +128,38 @@ def test_impersonate_rejects_target_without_profile(superuser, db):
     assert exc.value.status_code == 400
 
 
-def test_build_redirect_url_shape(superuser, client_user):
+def test_build_redirect_url_carries_only_code(superuser, client_user):
     tokens = impersonate(superuser, client_user)
-    url = build_impersonation_redirect_url(tokens, redirect_path='/platform')
+    code = create_exchange_code(tokens)
+    url = build_impersonation_redirect_url(code, redirect_path='/platform')
     assert '/platform/admin-login?' in url
-    assert 'access=' in url and 'refresh=' in url
+    assert f'code={code}' in url
+    assert 'access=' not in url and 'refresh=' not in url
     assert 'redirect=%2Fplatform' in url
+
+
+# ---------------------------------------------------------------------------
+# Exchange code (single-use, short-lived)
+# ---------------------------------------------------------------------------
+
+def test_exchange_code_round_trip(superuser, client_user):
+    tokens = impersonate(superuser, client_user)
+    code = create_exchange_code(tokens)
+    assert consume_exchange_code(code) == tokens
+
+
+def test_exchange_code_is_single_use(superuser, client_user):
+    code = create_exchange_code(impersonate(superuser, client_user))
+    assert consume_exchange_code(code) is not None
+    assert consume_exchange_code(code) is None
+
+
+def test_consume_unknown_code_returns_none():
+    assert consume_exchange_code('does-not-exist') is None
+
+
+def test_consume_empty_code_returns_none():
+    assert consume_exchange_code('') is None
 
 
 # ---------------------------------------------------------------------------
@@ -144,7 +172,10 @@ def test_endpoint_superuser_gets_redirect_url(api_client, superuser, client_user
         f'/api/accounts/admins/{client_user.id}/login-as/', **headers,
     )
     assert resp.status_code == 200
-    assert '/platform/admin-login?' in resp.json()['redirect_url']
+    redirect_url = resp.json()['redirect_url']
+    assert '/platform/admin-login?' in redirect_url
+    assert 'code=' in redirect_url
+    assert 'access=' not in redirect_url
 
 
 def test_endpoint_non_superuser_forbidden(api_client, staff_admin, client_user):
@@ -164,6 +195,52 @@ def test_endpoint_target_not_found(api_client, superuser):
 def test_endpoint_requires_auth(api_client, client_user):
     resp = api_client.post(f'/api/accounts/admins/{client_user.id}/login-as/')
     assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Exchange endpoint (public; the code is the bearer of trust)
+# ---------------------------------------------------------------------------
+
+def test_exchange_endpoint_swaps_code_for_tokens(api_client, superuser, client_user):
+    code = create_exchange_code(impersonate(superuser, client_user))
+    resp = api_client.post(
+        '/api/accounts/impersonation/exchange/', {'code': code}, format='json',
+    )
+    assert resp.status_code == 200
+    assert resp.json()['access'] and resp.json()['refresh']
+
+
+def test_exchange_endpoint_rejects_invalid_code(api_client):
+    resp = api_client.post(
+        '/api/accounts/impersonation/exchange/', {'code': 'nope'}, format='json',
+    )
+    assert resp.status_code == 400
+
+
+def test_exchange_endpoint_code_cannot_be_reused(api_client, superuser, client_user):
+    code = create_exchange_code(impersonate(superuser, client_user))
+    first = api_client.post(
+        '/api/accounts/impersonation/exchange/', {'code': code}, format='json',
+    )
+    second = api_client.post(
+        '/api/accounts/impersonation/exchange/', {'code': code}, format='json',
+    )
+    assert first.status_code == 200
+    assert second.status_code == 400
+
+
+def test_login_as_then_exchange_end_to_end(api_client, superuser, client_user):
+    headers = _bearer(api_client, 'root@test.com', 'rootpass1!')
+    login_as = api_client.post(
+        f'/api/accounts/admins/{client_user.id}/login-as/', **headers,
+    )
+    redirect_url = login_as.json()['redirect_url']
+    code = redirect_url.split('code=')[1].split('&')[0]
+    exchange = api_client.post(
+        '/api/accounts/impersonation/exchange/', {'code': code}, format='json',
+    )
+    assert exchange.status_code == 200
+    assert exchange.json()['access']
 
 
 # ---------------------------------------------------------------------------
@@ -202,6 +279,8 @@ def test_admin_login_as_view_success_redirects_to_frontend(superuser, client_use
     response = admin.login_as_user_view(request, client_user.id)
     assert response.status_code == 302
     assert '/platform/admin-login?' in response['Location']
+    assert 'code=' in response['Location']
+    assert 'access=' not in response['Location']
 
 
 def test_admin_login_as_view_failure_redirects_to_change(superuser, db):

--- a/backend/accounts/tests/test_impersonation.py
+++ b/backend/accounts/tests/test_impersonation.py
@@ -1,0 +1,216 @@
+"""Tests for the "Log in as this user" (impersonation) feature.
+
+Covers the shared service (accounts/services/impersonation.py), the panel DRF
+endpoint, and the Django admin button/view.
+"""
+import pytest
+from django.contrib.auth import get_user_model
+from django.contrib.messages.middleware import MessageMiddleware
+from django.contrib.sessions.middleware import SessionMiddleware
+from django.test import RequestFactory
+from rest_framework.test import APIClient
+
+from accounts.models import UserProfile
+from accounts.services.impersonation import (
+    ImpersonationError,
+    build_impersonation_redirect_url,
+    impersonate,
+)
+
+User = get_user_model()
+
+pytestmark = pytest.mark.django_db
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def api_client():
+    return APIClient()
+
+
+@pytest.fixture
+def superuser(db):
+    user = User.objects.create_superuser(
+        username='root@test.com', email='root@test.com', password='rootpass1!',
+        first_name='Root', last_name='Admin',
+    )
+    UserProfile.objects.create(user=user, role=UserProfile.ROLE_ADMIN, is_onboarded=True)
+    return user
+
+
+@pytest.fixture
+def staff_admin(db):
+    user = User.objects.create_user(
+        username='staff@test.com', email='staff@test.com', password='staffpass1!',
+        is_staff=True,
+    )
+    UserProfile.objects.create(user=user, role=UserProfile.ROLE_ADMIN, is_onboarded=True)
+    return user
+
+
+@pytest.fixture
+def client_user(db, superuser):
+    user = User.objects.create_user(
+        username='client@test.com', email='client@test.com', password='clientpass1!',
+        first_name='Client', last_name='User',
+    )
+    UserProfile.objects.create(
+        user=user, role=UserProfile.ROLE_CLIENT, is_onboarded=True, profile_completed=True,
+        created_by=superuser,
+    )
+    return user
+
+
+def _bearer(api_client, email, password):
+    resp = api_client.post(
+        '/api/accounts/login/', {'email': email, 'password': password}, format='json',
+    )
+    return {'HTTP_AUTHORIZATION': f"Bearer {resp.json()['tokens']['access']}"}
+
+
+# ---------------------------------------------------------------------------
+# Service rules
+# ---------------------------------------------------------------------------
+
+def test_impersonate_happy_path_returns_tokens(superuser, client_user):
+    tokens = impersonate(superuser, client_user)
+    assert tokens['access']
+    assert tokens['refresh']
+
+
+def test_impersonate_rejects_non_superuser_actor(staff_admin, client_user):
+    with pytest.raises(ImpersonationError) as exc:
+        impersonate(staff_admin, client_user)
+    assert exc.value.status_code == 403
+
+
+def test_impersonate_rejects_inactive_superuser_actor(superuser, client_user):
+    superuser.is_active = False
+    with pytest.raises(ImpersonationError) as exc:
+        impersonate(superuser, client_user)
+    assert exc.value.status_code == 403
+
+
+def test_impersonate_rejects_other_superuser_target(superuser, db):
+    other = User.objects.create_superuser(
+        username='root2@test.com', email='root2@test.com', password='x',
+    )
+    UserProfile.objects.create(user=other, role=UserProfile.ROLE_ADMIN)
+    with pytest.raises(ImpersonationError) as exc:
+        impersonate(superuser, other)
+    assert exc.value.status_code == 403
+
+
+def test_impersonate_allows_self_superuser(superuser):
+    tokens = impersonate(superuser, superuser)
+    assert tokens['access']
+
+
+def test_impersonate_rejects_inactive_target(superuser, client_user):
+    client_user.is_active = False
+    client_user.save(update_fields=['is_active'])
+    with pytest.raises(ImpersonationError) as exc:
+        impersonate(superuser, client_user)
+    assert exc.value.status_code == 400
+
+
+def test_impersonate_rejects_target_without_profile(superuser, db):
+    no_profile = User.objects.create_user(
+        username='noprofile@test.com', email='noprofile@test.com', password='x',
+    )
+    with pytest.raises(ImpersonationError) as exc:
+        impersonate(superuser, no_profile)
+    assert exc.value.status_code == 400
+
+
+def test_build_redirect_url_shape(superuser, client_user):
+    tokens = impersonate(superuser, client_user)
+    url = build_impersonation_redirect_url(tokens, redirect_path='/platform')
+    assert '/platform/admin-login?' in url
+    assert 'access=' in url and 'refresh=' in url
+    assert 'redirect=%2Fplatform' in url
+
+
+# ---------------------------------------------------------------------------
+# Panel DRF endpoint
+# ---------------------------------------------------------------------------
+
+def test_endpoint_superuser_gets_redirect_url(api_client, superuser, client_user):
+    headers = _bearer(api_client, 'root@test.com', 'rootpass1!')
+    resp = api_client.post(
+        f'/api/accounts/admins/{client_user.id}/login-as/', **headers,
+    )
+    assert resp.status_code == 200
+    assert '/platform/admin-login?' in resp.json()['redirect_url']
+
+
+def test_endpoint_non_superuser_forbidden(api_client, staff_admin, client_user):
+    headers = _bearer(api_client, 'staff@test.com', 'staffpass1!')
+    resp = api_client.post(
+        f'/api/accounts/admins/{client_user.id}/login-as/', **headers,
+    )
+    assert resp.status_code == 403
+
+
+def test_endpoint_target_not_found(api_client, superuser):
+    headers = _bearer(api_client, 'root@test.com', 'rootpass1!')
+    resp = api_client.post('/api/accounts/admins/999999/login-as/', **headers)
+    assert resp.status_code == 404
+
+
+def test_endpoint_requires_auth(api_client, client_user):
+    resp = api_client.post(f'/api/accounts/admins/{client_user.id}/login-as/')
+    assert resp.status_code in (401, 403)
+
+
+# ---------------------------------------------------------------------------
+# Django admin
+# ---------------------------------------------------------------------------
+
+def _admin_instance():
+    from content.admin import ProjectAppUserAdmin, admin_site
+    return ProjectAppUserAdmin(User, admin_site)
+
+
+def _request_with_messages(method, path, user):
+    factory = RequestFactory()
+    request = getattr(factory, method)(path)
+    request.user = user
+    SessionMiddleware(lambda r: None).process_request(request)
+    MessageMiddleware(lambda r: None).process_request(request)
+    return request
+
+
+def test_admin_impersonate_link_renders_button(client_user):
+    admin = _admin_instance()
+    html = admin.impersonate_link(client_user)
+    assert 'Log in as this user' in html
+    assert f'/{client_user.id}/login_as/' in html
+
+
+def test_admin_impersonate_link_blank_for_unsaved():
+    admin = _admin_instance()
+    assert admin.impersonate_link(User()) == '—'
+
+
+def test_admin_login_as_view_success_redirects_to_frontend(superuser, client_user):
+    admin = _admin_instance()
+    request = _request_with_messages('post', '/admin/', superuser)
+    response = admin.login_as_user_view(request, client_user.id)
+    assert response.status_code == 302
+    assert '/platform/admin-login?' in response['Location']
+
+
+def test_admin_login_as_view_failure_redirects_to_change(superuser, db):
+    other = User.objects.create_superuser(
+        username='root3@test.com', email='root3@test.com', password='x',
+    )
+    UserProfile.objects.create(user=other, role=UserProfile.ROLE_ADMIN)
+    admin = _admin_instance()
+    request = _request_with_messages('post', '/admin/', superuser)
+    response = admin.login_as_user_view(request, other.id)
+    assert response.status_code == 302
+    assert 'admin-login' not in response['Location']

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -17,6 +17,7 @@ from accounts.views_saved_filter_tabs import (
 from accounts.views import (
     admin_detail_view,
     admin_list_view,
+    admin_login_as_view,
     admin_resend_invite_view,
     bug_report_all_view,
     bug_report_bulk_evaluate_view,
@@ -114,6 +115,7 @@ urlpatterns = [
     path('admins/', admin_list_view, name='panel-admin-list'),
     path('admins/<int:user_id>/', admin_detail_view, name='panel-admin-detail'),
     path('admins/<int:user_id>/resend-invite/', admin_resend_invite_view, name='panel-admin-resend-invite'),
+    path('admins/<int:user_id>/login-as/', admin_login_as_view, name='panel-admin-login-as'),
 
     # Admin — client management
     path('clients/', client_list_view, name='platform-client-list'),

--- a/backend/accounts/urls.py
+++ b/backend/accounts/urls.py
@@ -19,6 +19,7 @@ from accounts.views import (
     admin_list_view,
     admin_login_as_view,
     admin_resend_invite_view,
+    impersonation_exchange_view,
     bug_report_all_view,
     bug_report_bulk_evaluate_view,
     bug_report_comment_view,
@@ -116,6 +117,7 @@ urlpatterns = [
     path('admins/<int:user_id>/', admin_detail_view, name='panel-admin-detail'),
     path('admins/<int:user_id>/resend-invite/', admin_resend_invite_view, name='panel-admin-resend-invite'),
     path('admins/<int:user_id>/login-as/', admin_login_as_view, name='panel-admin-login-as'),
+    path('impersonation/exchange/', impersonation_exchange_view, name='platform-impersonation-exchange'),
 
     # Admin — client management
     path('clients/', client_list_view, name='platform-client-list'),

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -38,6 +38,8 @@ from accounts.serializers import (
 from accounts.services.impersonation import (
     ImpersonationError,
     build_impersonation_redirect_url,
+    consume_exchange_code,
+    create_exchange_code,
     impersonate,
 )
 from accounts.services.onboarding import create_admin, create_client, resend_invitation
@@ -685,7 +687,25 @@ def admin_login_as_view(request, user_id):
         return Response({'detail': exc.message}, status=exc.status_code)
 
     logger.info('admin %s logged in as user %s', request.user, target)
-    return Response({'redirect_url': build_impersonation_redirect_url(tokens)})
+    code = create_exchange_code(tokens)
+    return Response({'redirect_url': build_impersonation_redirect_url(code)})
+
+
+@api_view(['POST'])
+@permission_classes([AllowAny])
+def impersonation_exchange_view(request):
+    """Swap a single-use impersonation code for the JWT tokens.
+
+    Called by the /platform/admin-login callback. The code itself is the
+    bearer of trust (short-lived, single-use), so no prior auth is required.
+    """
+    tokens = consume_exchange_code(request.data.get('code'))
+    if not tokens:
+        return Response(
+            {'detail': 'Código inválido o expirado.'},
+            status=status.HTTP_400_BAD_REQUEST,
+        )
+    return Response(tokens)
 
 
 # ==========================================================================

--- a/backend/accounts/views.py
+++ b/backend/accounts/views.py
@@ -35,6 +35,11 @@ from accounts.serializers import (
     UserProfileSerializer,
     VerifyOnboardingSerializer,
 )
+from accounts.services.impersonation import (
+    ImpersonationError,
+    build_impersonation_redirect_url,
+    impersonate,
+)
 from accounts.services.onboarding import create_admin, create_client, resend_invitation
 from accounts.services.password_reset import (
     PasswordResetError,
@@ -655,6 +660,32 @@ def admin_resend_invite_view(request, user_id):
 
     resend_invitation(profile.user)
     return Response({'detail': 'Invitación reenviada.'})
+
+
+@api_view(['POST'])
+@permission_classes([IsAuthenticated])
+def admin_login_as_view(request, user_id):
+    """Mint impersonation tokens for ``user_id`` and return the callback URL.
+
+    Superuser-only is enforced by the shared impersonation service. The
+    frontend opens ``redirect_url`` to establish the platform session.
+    """
+    User = get_user_model()
+    try:
+        target = User.objects.get(pk=user_id)
+    except User.DoesNotExist:
+        return Response(
+            {'detail': 'Usuario no encontrado.'},
+            status=status.HTTP_404_NOT_FOUND,
+        )
+
+    try:
+        tokens = impersonate(request.user, target)
+    except ImpersonationError as exc:
+        return Response({'detail': exc.message}, status=exc.status_code)
+
+    logger.info('admin %s logged in as user %s', request.user, target)
+    return Response({'redirect_url': build_impersonation_redirect_url(tokens)})
 
 
 # ==========================================================================

--- a/backend/content/admin.py
+++ b/backend/content/admin.py
@@ -1,7 +1,19 @@
-from django.contrib import admin
+import logging
+
+from django.contrib import admin, messages
 from django.contrib.auth.models import User, Group
 from django.contrib.auth.admin import UserAdmin, GroupAdmin
+from django.http import HttpResponseRedirect
+from django.shortcuts import get_object_or_404
+from django.urls import path, reverse
+from django.utils.html import format_html
 from django.utils.translation import gettext_lazy as _
+
+from accounts.services.impersonation import (
+    ImpersonationError,
+    build_impersonation_redirect_url,
+    impersonate,
+)
 from .models import (
     Contact, PortfolioWork,
     BusinessProposal, ProposalSection, ProposalRequirementGroup, ProposalRequirementItem,
@@ -29,6 +41,9 @@ from .models import (
     LinkedInToken,
     Task,
 )
+
+logger = logging.getLogger(__name__)
+
 
 class PortfolioWorkAdmin(admin.ModelAdmin):
     """
@@ -379,6 +394,63 @@ admin_site.register(DiagnosticSection)
 admin_site.register(EmailLog)
 admin_site.register(LinkedInToken)
 
+class ProjectAppUserAdmin(UserAdmin):
+    """Stock ``auth.User`` admin plus a "Log in as this user" button."""
+
+    def get_fieldsets(self, request, obj=None):
+        fieldsets = super().get_fieldsets(request, obj)
+        if obj is None:
+            return fieldsets
+        fieldsets = [(name, dict(opts)) for name, opts in fieldsets]
+        section_name, section_opts = fieldsets[0]
+        fields = list(section_opts.get('fields', ()))
+        if 'impersonate_link' not in fields:
+            fields.append('impersonate_link')
+        section_opts['fields'] = tuple(fields)
+        fieldsets[0] = (section_name, section_opts)
+        return fieldsets
+
+    def get_readonly_fields(self, request, obj=None):
+        readonly = list(super().get_readonly_fields(request, obj))
+        if 'impersonate_link' not in readonly:
+            readonly.append('impersonate_link')
+        return readonly
+
+    def impersonate_link(self, obj):
+        if not obj or not obj.pk:
+            return '—'
+        url = reverse('myadmin:auth_user_login_as', args=[obj.pk])
+        return format_html(
+            '<a class="button" href="{}" style="text-decoration:none" '
+            'target="_blank" rel="noopener">Log in as this user</a>',
+            url,
+        )
+    impersonate_link.short_description = 'Impersonate'
+
+    def get_urls(self):
+        custom = [
+            path(
+                '<int:user_id>/login_as/',
+                self.admin_site.admin_view(self.login_as_user_view),
+                name='auth_user_login_as',
+            ),
+        ]
+        return custom + super().get_urls()
+
+    def login_as_user_view(self, request, user_id):
+        target = get_object_or_404(User, pk=user_id)
+        change_url = reverse('myadmin:auth_user_change', args=[user_id])
+        try:
+            tokens = impersonate(request.user, target)
+        except ImpersonationError as exc:
+            messages.error(request, exc.message)
+            return HttpResponseRedirect(change_url)
+        logger.info(
+            'admin %s logged in as user %s', request.user, target,
+        )
+        return HttpResponseRedirect(build_impersonation_redirect_url(tokens))
+
+
 # Auth models
-admin_site.register(User, UserAdmin)
+admin_site.register(User, ProjectAppUserAdmin)
 admin_site.register(Group, GroupAdmin)

--- a/backend/content/admin.py
+++ b/backend/content/admin.py
@@ -12,6 +12,7 @@ from django.utils.translation import gettext_lazy as _
 from accounts.services.impersonation import (
     ImpersonationError,
     build_impersonation_redirect_url,
+    create_exchange_code,
     impersonate,
 )
 from .models import (
@@ -448,7 +449,8 @@ class ProjectAppUserAdmin(UserAdmin):
         logger.info(
             'admin %s logged in as user %s', request.user, target,
         )
-        return HttpResponseRedirect(build_impersonation_redirect_url(tokens))
+        code = create_exchange_code(tokens)
+        return HttpResponseRedirect(build_impersonation_redirect_url(code))
 
 
 # Auth models

--- a/backend/projectapp/settings.py
+++ b/backend/projectapp/settings.py
@@ -184,6 +184,10 @@ STORAGES = {
 
 FRONTEND_BASE_URL = config('FRONTEND_BASE_URL', default='http://localhost:3000')
 
+# Default locale segment for building locale-prefixed frontend URLs from the
+# backend (i18n strategy is "prefix", so the segment is always required).
+FRONTEND_DEFAULT_LOCALE = config('FRONTEND_DEFAULT_LOCALE', default='en-us')
+
 # Frontend prerender rebuild (blog SEO). The static build bakes blog posts
 # into HTML, so publishing content triggers a rebuild (content/tasks.py).
 # Disabled by default in dev so local publishes don't spawn npm builds.

--- a/docs/USER_FLOW_MAP.md
+++ b/docs/USER_FLOW_MAP.md
@@ -517,6 +517,23 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
 - **Coverage:** ✅ Covered
 - **E2E Spec:** `e2e/auth/auth-admin-login.spec.js`
 
+### FLOW: `admin-impersonate-user`
+
+- **Module:** admin
+- **Role:** admin (superuser only)
+- **Priority:** P2
+- **Routes:** `/panel/admins/` (or Django `/admin/` user page) → `/platform/admin-login` → `/platform/dashboard`
+- **Description:** A superuser starts an impersonation session ("Login with this user") to access the platform as the target user for support/QA.
+- **Steps:**
+  1. Superuser opens `/panel/admins/` and clicks "Login with this user" on a user row (or opens the Django admin user page and clicks the "Log in as this user" button).
+  2. Backend `POST /api/accounts/admins/<id>/login-as/` (or the admin `login_as` view) validates the policy and mints JWT tokens.
+  3. A new tab opens `/platform/admin-login?access=...&refresh=...&redirect=/platform`.
+  4. The callback page stores the tokens and hydrates the session (`GET /api/accounts/me/`).
+  5. User lands authenticated on `/platform/dashboard` as the impersonated user.
+- **Security:** only active superusers; cannot impersonate another superuser; cannot impersonate inactive users; target must have a platform profile.
+- **Coverage:** ⚠️ Pending (registered, E2E spec not yet implemented)
+- **E2E Spec:** _suggested:_ `e2e/admin/admin-impersonate-user.spec.js`
+
 ### FLOW: `admin-dashboard`
 
 - **Module:** admin
@@ -2280,6 +2297,7 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
 | `proposal-share` | proposal | guest | P2 | ✅ Covered | `e2e/proposal/proposal-share.spec.js` |
 | `proposal-engagement-tracking` | proposal | guest | P2 | ✅ Covered | `e2e/proposal/proposal-engagement-tracking.spec.js` |
 | `admin-login` | auth | admin | P1 | ✅ Covered | `e2e/auth/auth-admin-login.spec.js` |
+| `admin-impersonate-user` | admin | admin | P2 | ⚠️ Pending | _suggested:_ `e2e/admin/admin-impersonate-user.spec.js` |
 | `admin-dashboard` | admin | admin | P2 | ✅ Covered | `e2e/admin/admin-dashboard.spec.js` |
 | `admin-proposal-list` | admin | admin | P1 | ✅ Covered | `e2e/admin/admin-proposal-list.spec.js` |
 | `admin-proposal-create` | admin | admin | P1 | ✅ Covered | `e2e/admin/admin-proposal-create.spec.js` |

--- a/docs/USER_FLOW_MAP.md
+++ b/docs/USER_FLOW_MAP.md
@@ -526,9 +526,9 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
 - **Description:** A superuser starts an impersonation session ("Login with this user") to access the platform as the target user for support/QA.
 - **Steps:**
   1. Superuser opens `/panel/admins/` and clicks "Login with this user" on a user row (or opens the Django admin user page and clicks the "Log in as this user" button).
-  2. Backend `POST /api/accounts/admins/<id>/login-as/` (or the admin `login_as` view) validates the policy and mints JWT tokens.
-  3. A new tab opens `/platform/admin-login?access=...&refresh=...&redirect=/platform`.
-  4. The callback page stores the tokens and hydrates the session (`GET /api/accounts/me/`).
+  2. Backend `POST /api/accounts/admins/<id>/login-as/` (or the admin `login_as` view) validates the policy, mints JWT tokens, and stores them behind a short-lived single-use exchange code.
+  3. A new tab opens `/platform/admin-login?code=...&redirect=/platform` (no tokens on the URL).
+  4. The callback page POSTs the code to `POST /api/accounts/impersonation/exchange/`, receives the tokens, and hydrates the session (`GET /api/accounts/me/`).
   5. User lands authenticated on `/platform/dashboard` as the impersonated user.
 - **Security:** only active superusers; cannot impersonate another superuser; cannot impersonate inactive users; target must have a platform profile.
 - **Coverage:** ⚠️ Pending (registered, E2E spec not yet implemented)

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -156,6 +156,16 @@
       "description": "Admin authenticates to access the management panel.",
       "expectedSpecs": 1
     },
+    "admin-impersonate-user": {
+      "name": "Impersonate User (Login with this user)",
+      "module": "admin",
+      "roles": [
+        "admin"
+      ],
+      "priority": "P2",
+      "description": "A superuser clicks \"Login with this user\" (in /panel/admins/ or the Django admin user page) and lands authenticated on /platform via the /platform/admin-login callback that consumes the access/refresh tokens.",
+      "expectedSpecs": 1
+    },
     "admin-dashboard": {
       "name": "Admin Dashboard",
       "module": "admin",

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -163,7 +163,7 @@
         "admin"
       ],
       "priority": "P2",
-      "description": "A superuser clicks \"Login with this user\" (in /panel/admins/ or the Django admin user page) and lands authenticated on /platform via the /platform/admin-login callback that consumes the access/refresh tokens.",
+      "description": "A superuser clicks \"Login with this user\" (in /panel/admins/ or the Django admin user page) and lands authenticated on /platform via the /platform/admin-login callback, which swaps a short-lived single-use exchange code for the session tokens.",
       "expectedSpecs": 1
     },
     "admin-dashboard": {

--- a/frontend/e2e/helpers/flow-tags.js
+++ b/frontend/e2e/helpers/flow-tags.js
@@ -35,6 +35,7 @@ export const PROPOSAL_DOWNLOAD_PDF = ['@flow:proposal-download-pdf', '@module:pr
 export const ADMIN_LOGIN = ['@flow:admin-login', '@module:auth', '@priority:P1'];
 
 // ── Admin ──
+export const ADMIN_IMPERSONATE_USER = ['@flow:admin-impersonate-user', '@module:admin', '@priority:P2'];
 export const ADMIN_DASHBOARD = ['@flow:admin-dashboard', '@module:admin', '@priority:P2'];
 export const ADMIN_PROPOSAL_LIST = ['@flow:admin-proposal-list', '@module:admin', '@priority:P1'];
 export const ADMIN_PROPOSAL_CREATE = ['@flow:admin-proposal-create', '@module:admin', '@priority:P1'];

--- a/frontend/pages/panel/admins/index.vue
+++ b/frontend/pages/panel/admins/index.vue
@@ -84,6 +84,15 @@
 
           <button
             v-if="admin.is_active"
+            class="text-xs px-3 py-1.5 rounded-lg bg-surface-raised text-text-default hover:bg-border-muted font-medium transition-colors"
+            :disabled="loggingInId === admin.user_id"
+            @click="handleLoginAs(admin.user_id)"
+          >
+            {{ loggingInId === admin.user_id ? 'Abriendo...' : 'Login with this user' }}
+          </button>
+
+          <button
+            v-if="admin.is_active"
             class="text-xs px-3 py-1.5 rounded-lg bg-danger-soft text-danger-strong hover:opacity-90 font-medium transition-colors"
             @click="handleDeactivate(admin.user_id)"
           >
@@ -206,6 +215,7 @@ const showCreateModal = ref(false);
 const creating = ref(false);
 const createError = ref('');
 const resendingId = ref(null);
+const loggingInId = ref(null);
 const toast = ref(null);
 
 const form = ref({ email: '', first_name: '', last_name: '' });
@@ -282,6 +292,18 @@ async function handleResendInvite(userId) {
     showToast('Invitación reenviada.');
   } else {
     showToast(result.error, 'error');
+  }
+}
+
+async function handleLoginAs(userId) {
+  loggingInId.value = userId;
+  const result = await adminStore.loginAsUser(userId);
+  loggingInId.value = null;
+
+  if (result.success && result.redirectUrl) {
+    window.open(result.redirectUrl, '_blank', 'noopener');
+  } else {
+    showToast(result.error || 'No pudimos iniciar sesión como este usuario.', 'error');
   }
 }
 

--- a/frontend/pages/platform/admin-login.vue
+++ b/frontend/pages/platform/admin-login.vue
@@ -1,0 +1,48 @@
+<template>
+  <div class="flex min-h-screen items-center justify-center bg-surface px-4 text-sm text-text-subtle">
+    {{ message }}
+  </div>
+</template>
+
+<script setup>
+import { onMounted, ref } from 'vue'
+import { usePlatformAuthStore } from '~/stores/platform-auth'
+
+// No platform-auth middleware: this page establishes the session itself.
+definePageMeta({ layout: false })
+
+useHead({ title: 'Iniciando sesión — ProjectApp' })
+
+const route = useRoute()
+const localePath = useLocalePath()
+const authStore = usePlatformAuthStore()
+const message = ref('Iniciando sesión...')
+
+onMounted(async () => {
+  localStorage.setItem('platform_theme', 'light')
+
+  const access = typeof route.query.access === 'string' ? route.query.access : ''
+  const refresh = typeof route.query.refresh === 'string' ? route.query.refresh : ''
+
+  if (!access || !refresh) {
+    await navigateTo(localePath('/platform/login'))
+    return
+  }
+
+  authStore.applyAuthenticatedSession({ access, refresh }, null)
+  const result = await authStore.fetchMe()
+
+  if (!result.success) {
+    message.value = 'No pudimos iniciar la sesión.'
+    await navigateTo(localePath('/platform/login'))
+    return
+  }
+
+  const redirect = route.query.redirect
+  const target = typeof redirect === 'string' && redirect.startsWith('/platform/')
+    ? redirect
+    : '/platform/dashboard'
+
+  await navigateTo(localePath(target))
+})
+</script>

--- a/frontend/pages/platform/admin-login.vue
+++ b/frontend/pages/platform/admin-login.vue
@@ -21,17 +21,21 @@ const message = ref('Iniciando sesión...')
 onMounted(async () => {
   localStorage.setItem('platform_theme', 'light')
 
-  const access = typeof route.query.access === 'string' ? route.query.access : ''
-  const refresh = typeof route.query.refresh === 'string' ? route.query.refresh : ''
+  const code = typeof route.query.code === 'string' ? route.query.code : ''
 
-  if (!access || !refresh) {
+  if (!code) {
     await navigateTo(localePath('/platform/login'))
     return
   }
 
-  authStore.applyAuthenticatedSession({ access, refresh }, null)
-  const result = await authStore.fetchMe()
+  const exchange = await authStore.exchangeImpersonationCode(code)
+  if (!exchange.success) {
+    message.value = exchange.message || 'No pudimos iniciar la sesión.'
+    await navigateTo(localePath('/platform/login'))
+    return
+  }
 
+  const result = await authStore.fetchMe()
   if (!result.success) {
     message.value = 'No pudimos iniciar la sesión.'
     await navigateTo(localePath('/platform/login'))

--- a/frontend/stores/panel_admins.js
+++ b/frontend/stores/panel_admins.js
@@ -90,5 +90,15 @@ export const usePanelAdminsStore = defineStore('panel_admins', {
         return { success: false, error: detail };
       }
     },
+
+    async loginAsUser(userId) {
+      try {
+        const response = await create_request(`accounts/admins/${userId}/login-as/`, {});
+        return { success: true, redirectUrl: response.data.redirect_url };
+      } catch (error) {
+        const detail = error.response?.data?.detail || 'No pudimos iniciar sesión como este usuario.';
+        return { success: false, error: detail };
+      }
+    },
   },
 });

--- a/frontend/stores/platform-auth.js
+++ b/frontend/stores/platform-auth.js
@@ -395,6 +395,29 @@ export const usePlatformAuthStore = defineStore('platformAuth', {
       }
     },
 
+    async exchangeImpersonationCode(code) {
+      if (!code) {
+        return { success: false, message: 'Código de acceso ausente.' }
+      }
+      try {
+        const { post } = usePlatformApi()
+        const response = await post(
+          'impersonation/exchange/',
+          { code },
+          { skipAuth: true, skipRefresh: true },
+        )
+        this.applyAuthenticatedSession(
+          { access: response.data.access, refresh: response.data.refresh },
+          null,
+        )
+        return { success: true }
+      } catch (error) {
+        const message = error.response?.data?.detail || 'No pudimos iniciar la sesión.'
+        this.error = message
+        return { success: false, message }
+      }
+    },
+
     async fetchMe() {
       if (!this.accessToken) {
         return { success: false, message: 'No hay sesión activa.' }

--- a/frontend/test/components/PlatformAdminLogin.test.js
+++ b/frontend/test/components/PlatformAdminLogin.test.js
@@ -7,7 +7,7 @@ global.useRoute = () => ({ query: mockQuery, path: '/platform/admin-login' });
 global.navigateTo = jest.fn();
 
 const mockAuthStore = {
-  applyAuthenticatedSession: jest.fn(),
+  exchangeImpersonationCode: jest.fn(),
   fetchMe: jest.fn(),
 };
 
@@ -22,43 +22,52 @@ describe('platform/admin-login page', () => {
   beforeEach(() => {
     mockQuery = {};
     global.navigateTo.mockReset();
-    mockAuthStore.applyAuthenticatedSession.mockReset();
+    mockAuthStore.exchangeImpersonationCode.mockReset().mockResolvedValue({ success: true });
     mockAuthStore.fetchMe.mockReset().mockResolvedValue({ success: true });
   });
 
-  it('redirects to login when tokens are missing', async () => {
+  it('redirects to login when the code is missing', async () => {
     mockQuery = {};
     mount(AdminLogin);
     await flushPromises();
-    expect(mockAuthStore.applyAuthenticatedSession).not.toHaveBeenCalled();
+    expect(mockAuthStore.exchangeImpersonationCode).not.toHaveBeenCalled();
     expect(global.navigateTo).toHaveBeenCalledWith('/platform/login');
   });
 
-  it('stores tokens, hydrates and lands on dashboard by default', async () => {
-    mockQuery = { access: 'a', refresh: 'r' };
+  it('exchanges the code, hydrates and lands on dashboard by default', async () => {
+    mockQuery = { code: 'abc' };
     mount(AdminLogin);
     await flushPromises();
-    expect(mockAuthStore.applyAuthenticatedSession).toHaveBeenCalledWith({ access: 'a', refresh: 'r' }, null);
+    expect(mockAuthStore.exchangeImpersonationCode).toHaveBeenCalledWith('abc');
     expect(mockAuthStore.fetchMe).toHaveBeenCalled();
     expect(global.navigateTo).toHaveBeenCalledWith('/platform/dashboard');
   });
 
   it('honors a platform redirect target', async () => {
-    mockQuery = { access: 'a', refresh: 'r', redirect: '/platform/projects' };
+    mockQuery = { code: 'abc', redirect: '/platform/projects' };
     mount(AdminLogin);
     await flushPromises();
     expect(global.navigateTo).toHaveBeenCalledWith('/platform/projects');
   });
 
   it('ignores a non-platform redirect target', async () => {
-    mockQuery = { access: 'a', refresh: 'r', redirect: 'https://evil.com' };
+    mockQuery = { code: 'abc', redirect: 'https://evil.com' };
     mount(AdminLogin);
     await flushPromises();
     expect(global.navigateTo).toHaveBeenCalledWith('/platform/dashboard');
   });
 
+  it('falls back to login when the exchange fails', async () => {
+    mockQuery = { code: 'abc' };
+    mockAuthStore.exchangeImpersonationCode.mockResolvedValue({ success: false });
+    mount(AdminLogin);
+    await flushPromises();
+    expect(mockAuthStore.fetchMe).not.toHaveBeenCalled();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/login');
+  });
+
   it('falls back to login when hydration fails', async () => {
-    mockQuery = { access: 'a', refresh: 'r' };
+    mockQuery = { code: 'abc' };
     mockAuthStore.fetchMe.mockResolvedValue({ success: false });
     mount(AdminLogin);
     await flushPromises();

--- a/frontend/test/components/PlatformAdminLogin.test.js
+++ b/frontend/test/components/PlatformAdminLogin.test.js
@@ -1,0 +1,67 @@
+global.definePageMeta = jest.fn();
+global.useHead = jest.fn();
+global.useLocalePath = () => (path) => path;
+
+let mockQuery = {};
+global.useRoute = () => ({ query: mockQuery, path: '/platform/admin-login' });
+global.navigateTo = jest.fn();
+
+const mockAuthStore = {
+  applyAuthenticatedSession: jest.fn(),
+  fetchMe: jest.fn(),
+};
+
+jest.mock('../../stores/platform-auth', () => ({
+  usePlatformAuthStore: () => mockAuthStore,
+}));
+
+import { mount, flushPromises } from '@vue/test-utils';
+import AdminLogin from '../../pages/platform/admin-login.vue';
+
+describe('platform/admin-login page', () => {
+  beforeEach(() => {
+    mockQuery = {};
+    global.navigateTo.mockReset();
+    mockAuthStore.applyAuthenticatedSession.mockReset();
+    mockAuthStore.fetchMe.mockReset().mockResolvedValue({ success: true });
+  });
+
+  it('redirects to login when tokens are missing', async () => {
+    mockQuery = {};
+    mount(AdminLogin);
+    await flushPromises();
+    expect(mockAuthStore.applyAuthenticatedSession).not.toHaveBeenCalled();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/login');
+  });
+
+  it('stores tokens, hydrates and lands on dashboard by default', async () => {
+    mockQuery = { access: 'a', refresh: 'r' };
+    mount(AdminLogin);
+    await flushPromises();
+    expect(mockAuthStore.applyAuthenticatedSession).toHaveBeenCalledWith({ access: 'a', refresh: 'r' }, null);
+    expect(mockAuthStore.fetchMe).toHaveBeenCalled();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/dashboard');
+  });
+
+  it('honors a platform redirect target', async () => {
+    mockQuery = { access: 'a', refresh: 'r', redirect: '/platform/projects' };
+    mount(AdminLogin);
+    await flushPromises();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/projects');
+  });
+
+  it('ignores a non-platform redirect target', async () => {
+    mockQuery = { access: 'a', refresh: 'r', redirect: 'https://evil.com' };
+    mount(AdminLogin);
+    await flushPromises();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/dashboard');
+  });
+
+  it('falls back to login when hydration fails', async () => {
+    mockQuery = { access: 'a', refresh: 'r' };
+    mockAuthStore.fetchMe.mockResolvedValue({ success: false });
+    mount(AdminLogin);
+    await flushPromises();
+    expect(global.navigateTo).toHaveBeenCalledWith('/platform/login');
+  });
+});

--- a/frontend/test/stores/panel_admins.test.js
+++ b/frontend/test/stores/panel_admins.test.js
@@ -282,4 +282,26 @@ describe('usePanelAdminsStore', () => {
     const result = await store.resendInvite(1)
     expect(result.error).toBe('Error al reenviar invitación.')
   })
+
+  it('loginAsUser posts and returns redirect url', async () => {
+    create_request.mockResolvedValueOnce({ data: { redirect_url: 'https://x/en-us/platform/admin-login?access=a' } })
+    const result = await store.loginAsUser(42)
+    expect(create_request).toHaveBeenCalledWith('accounts/admins/42/login-as/', {})
+    expect(result.success).toBe(true)
+    expect(result.redirectUrl).toContain('/platform/admin-login')
+  })
+
+  it('loginAsUser returns error detail on failure', async () => {
+    create_request.mockRejectedValueOnce({ response: { data: { detail: 'no autorizado' } } })
+    const result = await store.loginAsUser(42)
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('no autorizado')
+  })
+
+  it('loginAsUser uses default message when error has no detail', async () => {
+    create_request.mockRejectedValueOnce({})
+    const result = await store.loginAsUser(42)
+    expect(result.success).toBe(false)
+    expect(result.error).toBe('No pudimos iniciar sesión como este usuario.')
+  })
 })

--- a/frontend/test/stores/platform-auth.test.js
+++ b/frontend/test/stores/platform-auth.test.js
@@ -872,4 +872,32 @@ describe('usePlatformAuthStore', () => {
       expect(store.profileCompleted).toBe(false)
     })
   })
+
+  describe('exchangeImpersonationCode', () => {
+    it('returns error when code is missing', async () => {
+      const result = await store.exchangeImpersonationCode('')
+      expect(result.success).toBe(false)
+      expect(mockPost).not.toHaveBeenCalled()
+    })
+
+    it('posts the code and applies the session on success', async () => {
+      mockPost.mockResolvedValueOnce({ data: { access: 'a', refresh: 'r' } })
+      const result = await store.exchangeImpersonationCode('xyz')
+      expect(mockPost).toHaveBeenCalledWith(
+        'impersonation/exchange/',
+        { code: 'xyz' },
+        { skipAuth: true, skipRefresh: true },
+      )
+      expect(result.success).toBe(true)
+      expect(store.accessToken).toBe('a')
+      expect(store.isAuthenticated).toBe(true)
+    })
+
+    it('returns the error detail when the exchange fails', async () => {
+      mockPost.mockRejectedValueOnce({ response: { data: { detail: 'Código inválido o expirado.' } } })
+      const result = await store.exchangeImpersonationCode('xyz')
+      expect(result.success).toBe(false)
+      expect(result.message).toBe('Código inválido o expirado.')
+    })
+  })
 })


### PR DESCRIPTION
## Summary
Lets an active superuser start a platform session as another user for support/QA, mirroring the fleet base implementation reviewed in Tu Huella (staging).

Implemented in **both** surfaces with the same security policy as the reference (active superuser only; cannot impersonate another superuser; cannot impersonate inactive users; target must have a platform profile).

### Backend
- New shared service `accounts/services/impersonation.py` — centralizes the policy and mints JWT via `get_tokens_for_user`.
- Django admin `ProjectAppUserAdmin`: "Log in as this user" button next to the password field + `login_as` view (covers all users).
- Panel endpoint `POST /api/accounts/admins/<id>/login-as/` returns the callback URL.
- `FRONTEND_DEFAULT_LOCALE` setting for locale-prefixed URLs.

### Frontend
- New `/platform/admin-login` callback page swaps the exchange code for tokens, hydrates via `fetchMe`, and redirects.
- `panel_admins` store `loginAsUser` action + button in `/panel/admins/`.

### Docs / E2E
- Registered `admin-impersonate-user` flow in `flow-definitions.json`, `flow-tags.js`, `USER_FLOW_MAP.md`. **E2E spec pending.**

## Security
Tokens are **not** placed on any URL. The backend stores the minted tokens behind a single-use, 60s-TTL opaque exchange code (Django cache / Redis in prod); the callback URL carries only `?code=...`, and the frontend POSTs it to `POST /api/accounts/impersonation/exchange/` to obtain the tokens. Resolves the automated security review HIGH finding.

## Test plan
- Backend: `pytest accounts/tests/test_impersonation.py` (24 passed)
- Frontend: `PlatformAdminLogin` + `platform-auth` + `panel_admins` (128 passed)