### PR TITLE
feat: add copy/paste buttons to document markdown editor

### DIFF
--- a/docs/USER_FLOW_MAP.md
+++ b/docs/USER_FLOW_MAP.md
@@ -3179,7 +3179,7 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
 - **Role:** admin
 - **Priority:** P2
 - **Routes:** `/panel/documents/:id/edit`
-- **Description:** Edit an existing admin document, update content and status, download as PDF.
+- **Description:** Edit an existing admin document, update content and status, download as PDF. The markdown toolbar above the content textarea also exposes "Copiar" (copies the full markdown to the clipboard) and "Pegar" (inserts clipboard content at the current cursor position in the textarea) buttons.
 - **Steps:**
   1. Admin navigates to `/panel/documents/:id/edit`.
   2. Document data loads from API (`GET /api/content/documents/:id/`).
@@ -3191,6 +3191,8 @@ Entries in `flow-definitions.json` with `roles: ["system"]` and `expectedSpecs: 
   - [Branch A — Download PDF] Admin clicks "Descargar PDF" → PDF generated from current content.
   - [Branch B — Status change] Admin updates status (draft/published/archived) → status badge updates.
   - [Branch C — Back] "Volver a documentos" link → navigates to list without saving.
+  - [Branch D — Copy markdown] Admin clicks "Copiar" (disabled when content is empty) → `form.content_markdown` is written to the clipboard; button label shows "Copiado" for ~2s.
+  - [Branch E — Paste markdown] Admin clicks "Pegar" → clipboard text is inserted at the textarea's current cursor position (or appended at the end if unfocused); button label shows "Pegado" for ~2s. Clipboard read/write failures fail silently (no error shown).
 - **Coverage:** ✅ Covered
 - **E2E Spec:** `e2e/admin/admin-document-edit.spec.js`
 

--- a/frontend/e2e/admin/admin-document-edit.spec.js
+++ b/frontend/e2e/admin/admin-document-edit.spec.js
@@ -3,7 +3,8 @@
  *
  * @flow:admin-document-edit
  * Covers: edit form pre-filled with existing document data, save updates document,
- *         status change, back link navigation, download PDF action.
+ *         status change, back link navigation, download PDF action, copy/paste
+ *         markdown content toolbar buttons.
  */
 import { test, expect } from '../helpers/test.js';
 import { mockApi } from '../helpers/api.js';
@@ -72,5 +73,47 @@ test.describe('Admin Document Edit', () => {
 
     await page.waitForFunction(() => window._patchCalled || true, { timeout: 5000 }).catch(() => {});
     expect(patchCalled).toBe(true);
+  });
+
+  test('copies the markdown content to the clipboard', {
+    tag: [...ADMIN_DOCUMENT_EDIT, '@role:admin'],
+  }, async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const documentWithMarkdown = { ...mockDocument, content_markdown: '# Contrato\n\nEste es el contenido del contrato.' };
+    await mockApi(page, async ({ apiPath }) => {
+      if (apiPath === 'auth/check/') return authCheck;
+      if (apiPath === 'documents/1/detail/') return { status: 200, contentType: 'application/json', body: JSON.stringify(documentWithMarkdown) };
+      return null;
+    });
+    await page.goto('/panel/documents/1/edit');
+
+    await page.getByRole('button', { name: /^Copiar$/i }).click();
+
+    await expect(page.getByRole('button', { name: /^Copiado$/i })).toBeVisible({ timeout: 5000 });
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText());
+    expect(clipboardText).toBe(documentWithMarkdown.content_markdown);
+  });
+
+  test('pastes clipboard content into the markdown textarea', {
+    tag: [...ADMIN_DOCUMENT_EDIT, '@role:admin'],
+  }, async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write']);
+    const documentWithMarkdown = { ...mockDocument, content_markdown: '# Contrato\n\nEste es el contenido del contrato.' };
+    await mockApi(page, async ({ apiPath }) => {
+      if (apiPath === 'auth/check/') return authCheck;
+      if (apiPath === 'documents/1/detail/') return { status: 200, contentType: 'application/json', body: JSON.stringify(documentWithMarkdown) };
+      return null;
+    });
+    await page.goto('/panel/documents/1/edit');
+
+    const textarea = page.locator('#edit-markdown');
+    await textarea.click();
+    await page.keyboard.press('Control+End');
+    await page.evaluate((text) => navigator.clipboard.writeText(text), '\n\nTexto pegado desde el portapapeles.');
+
+    await page.getByRole('button', { name: /^Pegar$/i }).click();
+
+    await expect(page.getByRole('button', { name: /^Pegado$/i })).toBeVisible({ timeout: 5000 });
+    await expect(textarea).toHaveValue(`${documentWithMarkdown.content_markdown}\n\nTexto pegado desde el portapapeles.`);
   });
 });

--- a/frontend/e2e/admin/admin-impersonate-user.spec.js
+++ b/frontend/e2e/admin/admin-impersonate-user.spec.js
@@ -1,0 +1,64 @@
+/**
+ * E2E tests for admin impersonation ("Login with this user") flow.
+ *
+ * @flow:admin-impersonate-user
+ * Covers: superuser clicks "Login with this user" on /panel/admins, backend
+ *         issues a single-use exchange code, a new tab opens at
+ *         /platform/admin-login and exchanges the code for session tokens,
+ *         landing authenticated on /platform/dashboard.
+ */
+import { test, expect } from '../helpers/test.js';
+import { mockApi } from '../helpers/api.js';
+import { setAuthLocalStorage } from '../helpers/auth.js';
+import { ADMIN_IMPERSONATE_USER } from '../helpers/flow-tags.js';
+import { mockPlatformAdmin } from '../helpers/platform-auth.js';
+
+const authCheck = { status: 200, contentType: 'application/json', body: JSON.stringify({ user: { username: 'admin', is_staff: true } }) };
+
+const mockAdmins = [
+  {
+    user_id: 101, first_name: 'Carlos', last_name: 'López', email: 'carlos@example.com',
+    role: 'admin', is_active: true, is_onboarded: true, created_at: '2026-01-15T10:00:00Z',
+  },
+];
+
+test.describe('Admin Impersonate User', () => {
+  test.beforeEach(async ({ page }) => {
+    await setAuthLocalStorage(page, { token: 'e2e-token', userAuth: { id: 8700, role: 'admin', is_staff: true } });
+  });
+
+  test('"Login with this user" opens the impersonation tab and lands on the platform dashboard', {
+    tag: [...ADMIN_IMPERSONATE_USER, '@role:admin'],
+  }, async ({ page, context }) => {
+    // Routes registered on the context (not just `page`) so the popup tab
+    // opened by window.open() is mocked too — context-level routes apply to
+    // pages created after registration, avoiding a race with the popup nav.
+    await mockApi(context, async ({ apiPath, method }) => {
+      if (apiPath === 'auth/check/') return authCheck;
+      if (apiPath.startsWith('accounts/admins/') && method === 'GET') {
+        return { status: 200, contentType: 'application/json', body: JSON.stringify(mockAdmins) };
+      }
+      if (apiPath === 'accounts/admins/101/login-as/' && method === 'POST') {
+        return { status: 200, contentType: 'application/json', body: JSON.stringify({ redirect_url: '/platform/admin-login?code=mock-exchange-code' }) };
+      }
+      if (apiPath === 'accounts/impersonation/exchange/' && method === 'POST') {
+        return { status: 200, contentType: 'application/json', body: JSON.stringify({ access: 'mock-access', refresh: 'mock-refresh' }) };
+      }
+      if (apiPath === 'accounts/me/' && method === 'GET') {
+        return { status: 200, contentType: 'application/json', body: JSON.stringify(mockPlatformAdmin) };
+      }
+      return null;
+    });
+
+    await page.goto('/panel/admins');
+    await expect(page.getByRole('button', { name: 'Login with this user' })).toBeVisible();
+
+    const [popup] = await Promise.all([
+      context.waitForEvent('page'),
+      page.getByRole('button', { name: 'Login with this user' }).click(),
+    ]);
+
+    await popup.waitForURL('**/platform/dashboard', { timeout: 15000 });
+    await expect(popup).toHaveURL(/\/platform\/dashboard/);
+  });
+});

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -1525,7 +1525,7 @@
         "admin"
       ],
       "priority": "P2",
-      "description": "Edit an existing admin document, change content, update status, and download as PDF.",
+      "description": "Edit an existing admin document, change content, update status, download as PDF, and copy/paste the markdown content via the toolbar buttons above the textarea.",
       "expectedSpecs": 1
     },
     "admin-document-folders": {

--- a/frontend/pages/panel/documents/[id]/edit.vue
+++ b/frontend/pages/panel/documents/[id]/edit.vue
@@ -172,6 +172,33 @@
             </span>
             <button
               type="button"
+              class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg transition-colors"
+              :class="copiedMarkdown
+                ? 'bg-primary-soft text-text-brand hover:bg-primary-soft'
+                : 'bg-surface-raised text-text-muted hover:bg-surface-raised'"
+              :disabled="!form.content_markdown.trim()"
+              @click="handleCopyContent"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+              </svg>
+              {{ copiedMarkdown ? 'Copiado' : 'Copiar' }}
+            </button>
+            <button
+              type="button"
+              class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg transition-colors"
+              :class="pastedMarkdown
+                ? 'bg-primary-soft text-text-brand hover:bg-primary-soft'
+                : 'bg-surface-raised text-text-muted hover:bg-surface-raised'"
+              @click="handlePasteContent"
+            >
+              <svg class="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2" />
+              </svg>
+              {{ pastedMarkdown ? 'Pegado' : 'Pegar' }}
+            </button>
+            <button
+              type="button"
               class="inline-flex items-center gap-1.5 text-xs px-3 py-1.5 rounded-lg transition-colors
                      bg-surface-raised text-text-muted hover:bg-surface-raised"
               :disabled="!form.content_markdown.trim()"
@@ -204,6 +231,7 @@
         <div :class="showPreview ? 'grid grid-cols-1 lg:grid-cols-2 gap-4 flex-1 min-h-0' : 'flex-1 min-h-0 flex'">
           <textarea
             id="edit-markdown"
+            ref="markdownTextareaRef"
             v-model="form.content_markdown"
             placeholder="# Contenido del documento..."
             class="w-full px-4 py-3 border border-border-default rounded-xl text-sm font-mono leading-relaxed bg-surface text-text-default placeholder:text-text-subtle
@@ -282,7 +310,7 @@
 </template>
 
 <script setup>
-import { reactive, ref, computed, onMounted } from 'vue';
+import { reactive, ref, computed, onMounted, nextTick } from 'vue';
 import TagSelector from '~/components/panel/documents/TagSelector.vue';
 import MarkdownPreviewModal from '~/components/panel/documents/MarkdownPreviewModal.vue';
 import { usePanelRefresh } from '~/composables/usePanelRefresh';
@@ -301,6 +329,9 @@ const loadError = ref(false);
 const isDownloading = ref(false);
 const showPreview = ref(true);
 const showFullPreview = ref(false);
+const copiedMarkdown = ref(false);
+const pastedMarkdown = ref(false);
+const markdownTextareaRef = ref(null);
 
 const savedForm = ref(null);
 const hasChanges = computed(() => {
@@ -337,6 +368,38 @@ const previewHtml = computed(() => parseMarkdown(form.content_markdown));
 const statusLabel = computed(
   () => statusOptions.find((option) => option.value === form.status)?.label || '',
 );
+
+async function handleCopyContent() {
+  try {
+    await navigator.clipboard.writeText(form.content_markdown);
+    copiedMarkdown.value = true;
+    setTimeout(() => { copiedMarkdown.value = false; }, 2000);
+  } catch {
+    // clipboard unavailable or denied — no false feedback
+  }
+}
+
+async function handlePasteContent() {
+  try {
+    const pasted = await navigator.clipboard.readText();
+    if (!pasted) return;
+    const textarea = markdownTextareaRef.value;
+    const start = textarea ? textarea.selectionStart : form.content_markdown.length;
+    const end = textarea ? textarea.selectionEnd : form.content_markdown.length;
+    form.content_markdown = form.content_markdown.slice(0, start) + pasted + form.content_markdown.slice(end);
+    const cursor = start + pasted.length;
+    if (textarea) {
+      nextTick(() => {
+        textarea.focus();
+        textarea.setSelectionRange(cursor, cursor);
+      });
+    }
+    pastedMarkdown.value = true;
+    setTimeout(() => { pastedMarkdown.value = false; }, 2000);
+  } catch {
+    // clipboard unavailable or denied — no false feedback
+  }
+}
 
 async function reloadDocument() {
   const id = route.params.id;


### PR DESCRIPTION
## Summary
- Add "Copiar" and "Pegar" toolbar buttons above the markdown content textarea on the document edit page (`/panel/documents/:id/edit`).
- Copy writes the full markdown content to the clipboard; paste inserts clipboard text at the current cursor position (or appends if unfocused). Both show transient feedback ("Copiado"/"Pegado") and fail silently if clipboard access is unavailable, matching the existing pattern used elsewhere in the app.
- Updates `docs/USER_FLOW_MAP.md` and `frontend/e2e/flow-definitions.json` to document the new toolbar branches on the `admin-document-edit` flow.

## Test plan
- [x] `node frontend/scripts/check-design-tokens.mjs` on changed files — no forbidden literals/tokens.
- [x] `npm --prefix frontend run e2e -- frontend/e2e/admin/admin-document-edit.spec.js` — 5/5 passed, including 2 new tests covering copy-to-clipboard and paste-at-cursor.