### PR TITLE
FIX: MCP endpoint compatibility with claude.ai custom connectors

### DIFF
--- a/backend/content/tests/views/test_mcp_blog.py
+++ b/backend/content/tests/views/test_mcp_blog.py
@@ -58,6 +58,56 @@ class TestMcpEndpointAuth:
 
 
 @pytest.mark.django_db
+class TestMcpEndpointProtocolCompat:
+    """Streamable HTTP transport compliance for claude.ai's client probes."""
+
+    def test_get_sse_probe_returns_405_not_406(self, api_client, blog_connector):
+        # Spec: GET must get text/event-stream or exactly 405 — DRF's default
+        # negotiation used to 406 on an SSE-only Accept header.
+        _, token = blog_connector
+        response = api_client.get(_url(token), HTTP_ACCEPT='text/event-stream')
+        assert response.status_code == 405
+        assert 'POST' in response['Allow']
+
+    def test_delete_session_termination_returns_405(self, api_client, blog_connector):
+        _, token = blog_connector
+        response = api_client.delete(_url(token))
+        assert response.status_code == 405
+
+    def test_head_returns_405(self, api_client, blog_connector):
+        _, token = blog_connector
+        response = api_client.head(_url(token))
+        assert response.status_code == 405
+
+    def test_post_with_foreign_origin_is_rejected(self, api_client, blog_connector):
+        _, token = blog_connector
+        response = api_client.post(
+            _url(token), _rpc('ping'), format='json',
+            HTTP_ORIGIN='https://evil.example',
+        )
+        assert response.status_code == 403
+
+    def test_post_with_same_host_origin_is_accepted(self, api_client, blog_connector):
+        _, token = blog_connector
+        response = api_client.post(
+            _url(token), _rpc('ping'), format='json',
+            HTTP_ORIGIN='http://testserver',
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.parametrize('probe_path', [
+        '/.well-known/oauth-authorization-server',
+        '/.well-known/oauth-protected-resource',
+        '/.well-known/openid-configuration',
+    ])
+    def test_oauth_discovery_probes_return_404(self, api_client, probe_path):
+        # The SPA catch-all must not answer these with 200 HTML: claude.ai
+        # reads that as "OAuth-protected server" and derails connector setup.
+        response = api_client.get(probe_path)
+        assert response.status_code == 404
+
+
+@pytest.mark.django_db
 class TestMcpEndpointFlow:
     def test_initialize_handshake(self, api_client, blog_connector):
         _, token = blog_connector

--- a/backend/content/views/mcp_blog.py
+++ b/backend/content/views/mcp_blog.py
@@ -3,17 +3,19 @@ Blog Publisher MCP: public JSON-RPC endpoint (token-authenticated) and
 the panel management endpoints backing /panel/mcps.
 """
 import logging
+from urllib.parse import urlparse
 
-from django.http import Http404
+from django.http import Http404, HttpResponse
 from django.shortcuts import get_object_or_404
 from django.utils import timezone as tz
-from rest_framework import serializers, status
+from rest_framework import exceptions, serializers, status
 from rest_framework.decorators import (
     api_view,
     authentication_classes,
     permission_classes,
     throttle_classes,
 )
+from rest_framework.negotiation import DefaultContentNegotiation
 from rest_framework.permissions import AllowAny
 from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
@@ -37,6 +39,33 @@ class McpEndpointThrottle(AnonRateThrottle):
     scope = 'mcp'
 
 
+class McpContentNegotiation(DefaultContentNegotiation):
+    """
+    MCP clients probe with Accept: text/event-stream (SSE detection). DRF's
+    default negotiation raises 406 before the view runs, but the Streamable
+    HTTP spec requires a plain 405 for that probe. Fall back to the first
+    renderer (JSON) instead of erroring so the view controls the response.
+    """
+
+    def select_renderer(self, request, renderers, format_suffix=None):
+        try:
+            return super().select_renderer(request, renderers, format_suffix)
+        except exceptions.NotAcceptable:
+            return (renderers[0], renderers[0].media_type)
+
+
+def _origin_is_foreign(request):
+    """
+    Streamable HTTP spec: servers MUST validate the Origin header (DNS
+    rebinding defense). Server-to-server clients (claude.ai) send none;
+    a browser Origin from another host is rejected.
+    """
+    origin = request.headers.get('Origin')
+    if not origin:
+        return False
+    return urlparse(origin).netloc != request.get_host()
+
+
 def _touch_last_used(connector):
     now = tz.now()
     if connector.last_used_at and (now - connector.last_used_at).total_seconds() < LAST_USED_TOUCH_SECONDS:
@@ -51,8 +80,14 @@ def _touch_last_used(connector):
 def mcp_endpoint(request, slug, token):
     """
     MCP Streamable HTTP endpoint for a connector (e.g. blog).
-    Plain-JSON responses only (no SSE) — WSGI-compatible by design.
+    Plain-JSON responses only (no SSE) — WSGI-compatible by design. DRF
+    answers GET (SSE probe) and DELETE (session termination) with the
+    spec-mandated 405; McpContentNegotiation keeps an SSE-only Accept
+    header from short-circuiting into a 406.
     """
+    if _origin_is_foreign(request):
+        return HttpResponse(status=403)
+
     tools = TOOLS_BY_SLUG.get(slug)
     connector = McpConnector.objects.filter(slug=slug, is_active=True).first()
     if tools is None or connector is None or not connector.check_token(token):
@@ -67,6 +102,11 @@ def mcp_endpoint(request, slug, token):
     if payload is None:
         return Response(status=http_status)
     return Response(payload, status=http_status)
+
+
+# api_view exposes the wrapped APIView class as .cls; override negotiation so
+# an SSE-only Accept header reaches the view instead of 406ing in initial().
+mcp_endpoint.cls.content_negotiation_class = McpContentNegotiation
 
 
 # ---------------------------------------------------------------------------

--- a/backend/projectapp/urls.py
+++ b/backend/projectapp/urls.py
@@ -1,5 +1,5 @@
 from django.conf import settings
-from django.http import JsonResponse
+from django.http import HttpResponseNotFound, JsonResponse
 from django.urls import path, include, re_path
 from content.admin import admin_site
 from django.conf.urls.static import static
@@ -10,6 +10,16 @@ from content.views.blog import serve_sitemap_xml
 
 def health_check(request):
     return JsonResponse({"status": "ok", "project": "projectapp"})
+
+
+def oauth_discovery_not_found(request, *args, **kwargs):
+    """
+    MCP clients (claude.ai custom connectors) probe these OAuth discovery
+    endpoints; the SPA catch-all used to answer 200 HTML, which reads as
+    "OAuth-protected server" and derails the connector setup. A real 404
+    signals a no-auth (capability URL) server.
+    """
+    return HttpResponseNotFound()
 
 
 urlpatterns = [
@@ -24,6 +34,16 @@ urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
 
 if getattr(settings, 'ENABLE_SILK', False):
     urlpatterns += [path('silk/', include('silk.urls', namespace='silk'))]
+
+# OAuth/OpenID discovery probes must 404 (no-auth MCP server), not fall
+# through to the SPA catch-all which answers 200 HTML.
+urlpatterns += [
+    re_path(
+        r'^\.well-known/(oauth-authorization-server|oauth-protected-resource|openid-configuration)(/.*)?$',
+        oauth_discovery_not_found,
+        name='oauth-discovery-not-found',
+    ),
+]
 
 # Catch-all: serve pre-rendered Nuxt pages and public assets.
 # This must be LAST so admin, api, and media URLs take priority.

--- a/frontend/pages/panel/mcps/index.vue
+++ b/frontend/pages/panel/mcps/index.vue
@@ -31,12 +31,21 @@
       >
         <div class="flex items-start justify-between gap-3 mb-1">
           <h2 class="text-lg font-bold text-text-default">{{ connector.name }}</h2>
-          <BaseToggle
-            :model-value="connector.is_active"
-            :aria-label="`Activar ${connector.name}`"
-            :data-testid="`mcp-toggle-${connector.slug}`"
-            @update:model-value="(value) => onToggle(connector, value)"
-          />
+          <div class="flex items-center gap-2 flex-shrink-0">
+            <span
+              class="text-xs font-medium"
+              :class="connector.is_active ? 'text-success-strong' : 'text-text-subtle'"
+              :data-testid="`mcp-status-${connector.slug}`"
+            >
+              {{ connector.is_active ? 'Activo' : 'Inactivo' }}
+            </span>
+            <BaseToggle
+              :model-value="connector.is_active"
+              :aria-label="`Activar ${connector.name}`"
+              :data-testid="`mcp-toggle-${connector.slug}`"
+              @update:model-value="(value) => onToggle(connector, value)"
+            />
+          </div>
         </div>
         <p class="text-sm text-text-muted mb-4">{{ connector.description }}</p>
 


### PR DESCRIPTION
## Summary

Adding the Blog Publisher connector in claude.ai failed. Diagnosis against the MCP Streamable HTTP spec and live probes of production surfaced three compliance issues (plus one operator step — the connector toggle was never activated, so POST initialize returned 404 by design):

- **GET SSE probe answered 406, spec requires 405.** DRF's default content negotiation rejects `Accept: text/event-stream` before the view runs. A custom negotiation class now falls back to JSON so DRF's native 405 (with `Allow: POST`) reaches the client — the spec's signal for "no SSE, keep talking JSON-RPC over POST".
- **OAuth discovery probes got 200 HTML.** claude.ai probes `/.well-known/oauth-authorization-server`, `oauth-protected-resource` and `openid-configuration` when adding a connector; the Nuxt SPA catch-all answered 200, which reads as "OAuth-protected server" and derailed setup into an authenticate flow. These paths now return real 404s ahead of the catch-all.
- **Origin header was not validated.** The spec marks this MUST (DNS-rebinding defense). POSTs with a foreign browser Origin now get 403; server-to-server clients (no Origin) are unaffected.

## Test plan

- `pytest content/tests/views/test_mcp_blog.py` — 23 pass (7 new: SSE probe 405, DELETE/HEAD 405, foreign/same-host Origin, 3 discovery paths 404).
- Post-deploy: activate the connector toggle in /panel/mcps, regenerate the token, re-add the connector in claude.ai, and verify `curl -X POST` initialize returns 200 JSON.