### PR TITLE
FEAT: Documents MCP connector (claude.ai) for /panel/documents

### DIFF
--- a/backend/content/mcp/document_tools.py
+++ b/backend/content/mcp/document_tools.py
@@ -1,0 +1,381 @@
+"""
+Tool registry for the Documents MCP connector.
+
+Lets claude.ai browse the panel's document manager (/panel/documents):
+list folders, list/read markdown documents, and create/edit/delete them.
+Documents are authored in Markdown; the panel turns them into branded PDFs
+downstream, so producing correct Markdown is enough here.
+
+Guardrails baked in:
+- Only MARKDOWN-type documents are visible or mutable. Commercial
+  collection accounts (cuentas de cobro) live in the same table and are
+  deliberately out of reach.
+- Published documents cannot be deleted (unpublish first or use the panel).
+- Folders can be listed and created, but not renamed or deleted, so the MCP
+  cannot dismantle the existing structure.
+
+Each entry: {'name', 'description', 'input_schema', 'handler'}. Handlers
+receive the raw `arguments` dict, return a JSON-serializable dict, and raise
+ToolError for business errors. They reuse the exact same parser and
+document_type helpers as the panel so the PDF pipeline stays identical.
+"""
+from content.mcp.protocol import ToolError
+from content.models import Document, DocumentFolder
+from content.services.document_type_codes import MARKDOWN
+from content.services.document_type_utils import get_markdown_document_type
+from content.services.markdown_parser import markdown_to_blocks
+
+LANGUAGE_CHOICES = {c[0] for c in Document.Language.choices}
+STATUS_CHOICES = {c[0] for c in Document.Status.choices}
+COVER_TYPE_CHOICES = {c[0] for c in Document.CoverType.choices}
+
+
+# ── Querysets & lookups ──────────────────────────────────────────────────────
+
+def _markdown_qs():
+    """Only markdown documents — never commercial collection accounts."""
+    return Document.objects.filter(document_type__code=MARKDOWN)
+
+
+def _get_markdown_doc_or_error(document_id):
+    try:
+        return _markdown_qs().get(pk=int(document_id))
+    except (Document.DoesNotExist, TypeError, ValueError):
+        raise ToolError(
+            f'No existe un documento markdown con id={document_id}. '
+            'Usa list_documents para ver los disponibles.'
+        )
+
+
+def _resolve_folder(folder_id):
+    """Turn a folder_id argument into a DocumentFolder (or None for root)."""
+    if folder_id in (None, '', 'none', 'null'):
+        return None
+    try:
+        return DocumentFolder.objects.get(pk=int(folder_id))
+    except (DocumentFolder.DoesNotExist, TypeError, ValueError):
+        raise ToolError(
+            f'No existe una carpeta con id={folder_id}. '
+            'Usa list_folders para ver las disponibles.'
+        )
+
+
+# ── Payload shaping ──────────────────────────────────────────────────────────
+
+def _folder_path(folder):
+    names = [a.name for a in folder.get_ancestors()] + [folder.name]
+    return ' / '.join(names)
+
+
+def _folder_payload(folder):
+    return {
+        'id': folder.id,
+        'name': folder.name,
+        'path': _folder_path(folder),
+        'parent_id': folder.parent_id,
+        # Count only markdown docs, to match what list_documents exposes.
+        'document_count': folder.documents.filter(document_type__code=MARKDOWN).count(),
+    }
+
+
+def _doc_summary(doc):
+    return {
+        'id': doc.id,
+        'title': doc.title,
+        'slug': doc.slug,
+        'status': doc.status,
+        'language': doc.language,
+        'folder_id': doc.folder_id,
+        'folder_name': doc.folder.name if doc.folder else None,
+        'updated_at': doc.updated_at.isoformat() if doc.updated_at else None,
+    }
+
+
+def _doc_detail(doc):
+    return {**_doc_summary(doc), 'content_markdown': doc.content_markdown}
+
+
+def _build_content_json(doc, markdown_text):
+    """Mirror the panel views: meta header + parsed blocks for the PDF stage."""
+    return {
+        'meta': {
+            'title': doc.title,
+            'client_name': doc.client_name,
+            'cover_type': doc.cover_type,
+            'include_portada': doc.include_portada,
+            'include_subportada': doc.include_subportada,
+            'include_contraportada': doc.include_contraportada,
+        },
+        'blocks': markdown_to_blocks(markdown_text),
+    }
+
+
+# ── Handlers ─────────────────────────────────────────────────────────────────
+
+def list_folders(arguments):
+    folders = DocumentFolder.objects.all().select_related('parent')
+    return {'folders': [_folder_payload(f) for f in folders]}
+
+
+def create_folder(arguments):
+    name = (arguments.get('name') or '').strip()
+    if not name:
+        raise ToolError('El nombre de la carpeta es obligatorio.')
+    parent = _resolve_folder(arguments.get('parent_id'))
+    folder = DocumentFolder.objects.create(name=name, parent=parent)
+    return _folder_payload(folder)
+
+
+def list_documents(arguments):
+    try:
+        page = max(1, int(arguments.get('page', 1) or 1))
+        page_size = max(1, min(int(arguments.get('page_size', 20) or 20), 50))
+    except (TypeError, ValueError):
+        raise ToolError('page y page_size deben ser enteros.')
+
+    qs = _markdown_qs().select_related('folder')
+    folder_arg = arguments.get('folder_id')
+    if folder_arg == 'none':
+        qs = qs.filter(folder__isnull=True)
+    elif folder_arg not in (None, '', 'all'):
+        folder = _resolve_folder(folder_arg)
+        qs = qs.filter(folder=folder)
+
+    total = qs.count()
+    start = (page - 1) * page_size
+    page_docs = list(qs[start:start + page_size])
+    return {
+        'count': total,
+        'page': page,
+        'page_size': page_size,
+        'results': [_doc_summary(d) for d in page_docs],
+    }
+
+
+def read_document(arguments):
+    doc = _get_markdown_doc_or_error(arguments.get('document_id'))
+    return _doc_detail(doc)
+
+
+def create_document(arguments):
+    title = (arguments.get('title') or '').strip()
+    markdown_text = arguments.get('markdown')
+    if not title:
+        raise ToolError('title es obligatorio.')
+    if not isinstance(markdown_text, str) or not markdown_text.strip():
+        raise ToolError('markdown es obligatorio y debe ser texto.')
+
+    language = arguments.get('language', 'es')
+    if language not in LANGUAGE_CHOICES:
+        raise ToolError(f'language inválido: usa uno de {sorted(LANGUAGE_CHOICES)}.')
+
+    folder = _resolve_folder(arguments.get('folder_id'))
+    client_name = arguments.get('client_name', '') or ''
+
+    doc = Document(
+        title=title,
+        document_type=get_markdown_document_type(),
+        folder=folder,
+        client_name=client_name,
+        language=language,
+        content_markdown=markdown_text,
+    )
+    doc.content_json = _build_content_json(doc, markdown_text)
+    doc.save()
+    return _doc_detail(doc)
+
+
+def update_document(arguments):
+    doc = _get_markdown_doc_or_error(arguments.get('document_id'))
+
+    update_fields = set()
+    if 'title' in arguments:
+        title = (arguments.get('title') or '').strip()
+        if not title:
+            raise ToolError('title no puede quedar vacío.')
+        doc.title = title
+        update_fields.add('title')
+
+    if 'client_name' in arguments:
+        doc.client_name = arguments.get('client_name', '') or ''
+        update_fields.add('client_name')
+
+    if 'language' in arguments:
+        language = arguments.get('language')
+        if language not in LANGUAGE_CHOICES:
+            raise ToolError(f'language inválido: usa uno de {sorted(LANGUAGE_CHOICES)}.')
+        doc.language = language
+        update_fields.add('language')
+
+    if 'status' in arguments:
+        new_status = arguments.get('status')
+        if new_status not in STATUS_CHOICES:
+            raise ToolError(f'status inválido: usa uno de {sorted(STATUS_CHOICES)}.')
+        doc.status = new_status
+        update_fields.add('status')
+
+    if 'folder_id' in arguments:
+        doc.folder = _resolve_folder(arguments.get('folder_id'))
+        update_fields.add('folder')
+
+    markdown_changed = 'markdown' in arguments
+    if markdown_changed:
+        markdown_text = arguments.get('markdown')
+        if not isinstance(markdown_text, str) or not markdown_text.strip():
+            raise ToolError('markdown debe ser texto no vacío.')
+        doc.content_markdown = markdown_text
+        update_fields.add('content_markdown')
+
+    if not update_fields:
+        raise ToolError(
+            'No se indicó ningún campo para actualizar. Envía al menos uno de: '
+            'title, markdown, folder_id, status, client_name, language.'
+        )
+
+    # content_json must always reflect the current title/meta + markdown, so
+    # rebuild it whenever the markdown or any meta field changed.
+    doc.content_json = _build_content_json(doc, doc.content_markdown)
+    update_fields.add('content_json')
+    doc.save(update_fields=list(update_fields) + ['updated_at'])
+    return _doc_detail(doc)
+
+
+def delete_document(arguments):
+    doc = _get_markdown_doc_or_error(arguments.get('document_id'))
+    if doc.status == Document.Status.PUBLISHED:
+        raise ToolError(
+            'Este documento está publicado. Cámbialo a borrador con '
+            'update_document (status="draft") antes de eliminarlo, o bórralo '
+            'desde el panel.'
+        )
+    doc_id = doc.id
+    doc.delete()
+    return {'deleted': True, 'id': doc_id}
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+_DOCUMENT_ID_PROP = {
+    'document_id': {'type': 'integer', 'description': 'ID del documento markdown.'},
+}
+
+DOCUMENT_TOOLS = [
+    {
+        'name': 'list_folders',
+        'description': (
+            'Lista todas las carpetas del gestor de documentos con su ruta '
+            'jerárquica y cuántos documentos contiene cada una. Úsala para '
+            'saber dónde colocar o buscar documentos.'
+        ),
+        'input_schema': {'type': 'object', 'properties': {}},
+        'handler': list_folders,
+    },
+    {
+        'name': 'create_folder',
+        'description': (
+            'Crea una carpeta nueva para organizar documentos. Opcionalmente '
+            'anídala bajo otra con parent_id (de list_folders).'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'name': {'type': 'string', 'description': 'Nombre de la carpeta.'},
+                'parent_id': {
+                    'type': 'integer',
+                    'description': 'ID de la carpeta padre (omitir para raíz).',
+                },
+            },
+            'required': ['name'],
+        },
+        'handler': create_folder,
+    },
+    {
+        'name': 'list_documents',
+        'description': (
+            'Lista documentos markdown con paginación. Filtra por carpeta con '
+            'folder_id (un id, "none" para los que están en la raíz, o "all"). '
+            'Devuelve resúmenes sin el contenido; usa read_document para el markdown.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'folder_id': {
+                    'type': ['integer', 'string'],
+                    'description': 'ID de carpeta, "none" (raíz) o "all" (todas).',
+                },
+                'page': {'type': 'integer', 'default': 1},
+                'page_size': {'type': 'integer', 'default': 20, 'maximum': 50},
+            },
+        },
+        'handler': list_documents,
+    },
+    {
+        'name': 'read_document',
+        'description': 'Devuelve un documento markdown completo, incluido su content_markdown.',
+        'input_schema': {
+            'type': 'object',
+            'properties': _DOCUMENT_ID_PROP,
+            'required': ['document_id'],
+        },
+        'handler': read_document,
+    },
+    {
+        'name': 'create_document',
+        'description': (
+            'Crea un documento nuevo a partir de markdown. El sistema lo '
+            'convierte en PDF con marca luego; basta con enviar buen markdown. '
+            'Opcional: folder_id (de list_folders), language (es/en), client_name.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'title': {'type': 'string'},
+                'markdown': {'type': 'string', 'description': 'Contenido en Markdown.'},
+                'folder_id': {'type': 'integer', 'description': 'Carpeta destino (opcional).'},
+                'language': {'type': 'string', 'enum': ['es', 'en'], 'default': 'es'},
+                'client_name': {'type': 'string'},
+            },
+            'required': ['title', 'markdown'],
+        },
+        'handler': create_document,
+    },
+    {
+        'name': 'update_document',
+        'description': (
+            'Actualiza un documento markdown existente (parcial). Envía '
+            'document_id y al menos uno de: title, markdown, folder_id, '
+            'status (draft/published/archived), client_name, language. Al '
+            'cambiar el markdown se reprocesa el contenido para el PDF.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                **_DOCUMENT_ID_PROP,
+                'title': {'type': 'string'},
+                'markdown': {'type': 'string'},
+                'folder_id': {
+                    'type': ['integer', 'null'],
+                    'description': 'Carpeta destino (null para mover a la raíz).',
+                },
+                'status': {'type': 'string', 'enum': ['draft', 'published', 'archived']},
+                'client_name': {'type': 'string'},
+                'language': {'type': 'string', 'enum': ['es', 'en']},
+            },
+            'required': ['document_id'],
+        },
+        'handler': update_document,
+    },
+    {
+        'name': 'delete_document',
+        'description': (
+            'Elimina un documento markdown NO publicado. Los publicados no se '
+            'pueden borrar por MCP: pásalos a borrador primero o usa el panel.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': _DOCUMENT_ID_PROP,
+            'required': ['document_id'],
+        },
+        'handler': delete_document,
+    },
+]

--- a/backend/content/mcp/document_tools.py
+++ b/backend/content/mcp/document_tools.py
@@ -11,7 +11,7 @@ Guardrails baked in:
   collection accounts (cuentas de cobro) live in the same table and are
   deliberately out of reach.
 - Published documents cannot be deleted (unpublish first or use the panel).
-- Folders can be listed and created, but not renamed or deleted, so the MCP
+- Folders can be listed, created and renamed, but not deleted, so the MCP
   cannot dismantle the existing structure.
 
 Each entry: {'name', 'description', 'input_schema', 'handler'}. Handlers
@@ -123,6 +123,21 @@ def create_folder(arguments):
         raise ToolError('El nombre de la carpeta es obligatorio.')
     parent = _resolve_folder(arguments.get('parent_id'))
     folder = DocumentFolder.objects.create(name=name, parent=parent)
+    return _folder_payload(folder)
+
+
+def rename_folder(arguments):
+    folder_id = arguments.get('folder_id')
+    if folder_id in (None, '', 'none', 'null'):
+        raise ToolError('folder_id es obligatorio para renombrar una carpeta.')
+    folder = _resolve_folder(folder_id)
+    name = (arguments.get('name') or '').strip()
+    if not name:
+        raise ToolError('El nuevo nombre de la carpeta es obligatorio.')
+    # The slug is set once on creation and left untouched, so links and PDF
+    # references stay stable when only the display name changes.
+    folder.name = name
+    folder.save(update_fields=['name', 'updated_at'])
     return _folder_payload(folder)
 
 
@@ -288,6 +303,22 @@ DOCUMENT_TOOLS = [
             'required': ['name'],
         },
         'handler': create_folder,
+    },
+    {
+        'name': 'rename_folder',
+        'description': (
+            'Cambia el nombre de una carpeta existente. Envía folder_id (de '
+            'list_folders) y el nuevo name. No mueve ni borra la carpeta.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'folder_id': {'type': 'integer', 'description': 'ID de la carpeta a renombrar.'},
+                'name': {'type': 'string', 'description': 'Nuevo nombre.'},
+            },
+            'required': ['folder_id', 'name'],
+        },
+        'handler': rename_folder,
     },
     {
         'name': 'list_documents',

--- a/backend/content/migrations/0131_seed_documents_mcp_connector.py
+++ b/backend/content/migrations/0131_seed_documents_mcp_connector.py
@@ -1,0 +1,31 @@
+from django.db import migrations
+
+
+def seed_documents_connector(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    McpConnector.objects.get_or_create(
+        slug='documents',
+        defaults={
+            'name': 'Gestor de Documentos',
+            'description': (
+                'Permite a Claude (claude.ai) navegar las carpetas y '
+                'documentos del panel, y crear, leer, editar y eliminar '
+                'documentos markdown directamente.'
+            ),
+            'is_active': False,
+        },
+    )
+
+
+def unseed_documents_connector(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    McpConnector.objects.filter(slug='documents').delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('content', '0130_mcprequestlog'),
+    ]
+    operations = [
+        migrations.RunPython(seed_documents_connector, unseed_documents_connector),
+    ]

--- a/backend/content/migrations/0132_documents_mcp_connector_description.py
+++ b/backend/content/migrations/0132_documents_mcp_connector_description.py
@@ -1,0 +1,33 @@
+from django.db import migrations
+
+NEW_DESCRIPTION = (
+    'Da a Claude (claude.ai) acceso al gestor de documentos del panel: '
+    'listar, crear y renombrar carpetas, y listar, leer, crear, editar y '
+    'eliminar documentos en Markdown (que el panel convierte a PDF). '
+    'No accede a las cuentas de cobro, no borra documentos publicados ni '
+    'carpetas.'
+)
+
+OLD_DESCRIPTION = (
+    'Permite a Claude (claude.ai) navegar las carpetas y documentos del '
+    'panel, y crear, leer, editar y eliminar documentos markdown directamente.'
+)
+
+
+def set_new_description(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    McpConnector.objects.filter(slug='documents').update(description=NEW_DESCRIPTION)
+
+
+def set_old_description(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    McpConnector.objects.filter(slug='documents').update(description=OLD_DESCRIPTION)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('content', '0131_seed_documents_mcp_connector'),
+    ]
+    operations = [
+        migrations.RunPython(set_new_description, set_old_description),
+    ]

--- a/backend/content/tests/views/test_mcp_documents.py
+++ b/backend/content/tests/views/test_mcp_documents.py
@@ -67,12 +67,12 @@ def _make_doc(doc_type, **kwargs):
 
 @pytest.mark.django_db
 class TestDocumentsMcpToolList:
-    def test_exposes_the_seven_tools(self, api_client, documents_connector):
+    def test_exposes_the_eight_tools(self, api_client, documents_connector):
         _, token = documents_connector
         response = api_client.post(_url(token), _rpc('tools/list'), format='json')
         names = [t['name'] for t in response.data['result']['tools']]
         assert names == [
-            'list_folders', 'create_folder', 'list_documents',
+            'list_folders', 'create_folder', 'rename_folder', 'list_documents',
             'read_document', 'create_document', 'update_document',
             'delete_document',
         ]
@@ -110,6 +110,21 @@ class TestDocumentsMcpFolders:
     def test_create_folder_requires_name(self, api_client, documents_connector):
         _, token = documents_connector
         response = _call(api_client, token, 'create_folder', {'name': '   '})
+        assert response.data['result']['isError'] is True
+
+    def test_rename_folder_changes_name_keeps_slug(self, api_client, documents_connector):
+        folder = DocumentFolder.objects.create(name='Viejo')
+        original_slug = folder.slug
+        _, token = documents_connector
+        response = _call(api_client, token, 'rename_folder', {'folder_id': folder.id, 'name': 'Nuevo'})
+        assert response.data['result']['isError'] is False
+        folder.refresh_from_db()
+        assert folder.name == 'Nuevo'
+        assert folder.slug == original_slug
+
+    def test_rename_folder_requires_folder_id(self, api_client, documents_connector):
+        _, token = documents_connector
+        response = _call(api_client, token, 'rename_folder', {'name': 'Nuevo'})
         assert response.data['result']['isError'] is True
 
 

--- a/backend/content/tests/views/test_mcp_documents.py
+++ b/backend/content/tests/views/test_mcp_documents.py
@@ -1,0 +1,213 @@
+"""Tests for the Documents MCP connector HTTP endpoint."""
+import pytest
+
+from content.models import Document, DocumentFolder, DocumentType, McpConnector
+
+
+@pytest.fixture
+def markdown_doc_type(db):
+    """Reuse or create the 'markdown' DocumentType (seeded by migration 0052)."""
+    obj, _ = DocumentType.objects.get_or_create(
+        code='markdown',
+        defaults={'name': 'Markdown', 'label': 'Markdown'},
+    )
+    return obj
+
+
+@pytest.fixture
+def collection_account_type(db):
+    obj, _ = DocumentType.objects.get_or_create(
+        code='collection_account',
+        defaults={'name': 'Cuenta de cobro', 'label': 'Cuenta de cobro'},
+    )
+    return obj
+
+
+@pytest.fixture
+def documents_connector(db):
+    connector, _ = McpConnector.objects.get_or_create(
+        slug='documents', defaults={'name': 'Gestor de Documentos'},
+    )
+    connector.is_active = True
+    connector.save(update_fields=['is_active'])
+    token = connector.generate_token()
+    return connector, token
+
+
+def _url(token):
+    return f'/api/mcp/documents/{token}/'
+
+
+def _rpc(method, params=None, msg_id=1):
+    message = {'jsonrpc': '2.0', 'id': msg_id, 'method': method}
+    if params is not None:
+        message['params'] = params
+    return message
+
+
+def _call(api_client, token, name, arguments):
+    return api_client.post(
+        _url(token),
+        _rpc('tools/call', {'name': name, 'arguments': arguments}),
+        format='json',
+    )
+
+
+def _make_doc(doc_type, **kwargs):
+    defaults = {
+        'title': 'Doc',
+        'document_type': doc_type,
+        'language': 'es',
+        'content_markdown': '# Hola\n\nMundo.',
+        'content_json': {'meta': {}, 'blocks': []},
+    }
+    defaults.update(kwargs)
+    return Document.objects.create(**defaults)
+
+
+@pytest.mark.django_db
+class TestDocumentsMcpToolList:
+    def test_exposes_the_seven_tools(self, api_client, documents_connector):
+        _, token = documents_connector
+        response = api_client.post(_url(token), _rpc('tools/list'), format='json')
+        names = [t['name'] for t in response.data['result']['tools']]
+        assert names == [
+            'list_folders', 'create_folder', 'list_documents',
+            'read_document', 'create_document', 'update_document',
+            'delete_document',
+        ]
+
+    def test_serverinfo_handshake_works_on_shared_endpoint(self, api_client, documents_connector):
+        _, token = documents_connector
+        response = api_client.post(
+            _url(token), _rpc('initialize', {'protocolVersion': '2025-06-18'}),
+            format='json',
+        )
+        assert response.status_code == 200
+        assert response.data['result']['capabilities']['tools'] == {}
+
+
+@pytest.mark.django_db
+class TestDocumentsMcpFolders:
+    def test_list_folders_returns_path_and_counts(self, api_client, documents_connector, markdown_doc_type):
+        parent = DocumentFolder.objects.create(name='Clientes')
+        child = DocumentFolder.objects.create(name='ACME', parent=parent)
+        _make_doc(markdown_doc_type, folder=child)
+        _, token = documents_connector
+
+        response = _call(api_client, token, 'list_folders', {})
+        folders = response.data['result']['content'][0]['text']
+        assert 'Clientes / ACME' in folders
+
+    def test_create_folder_under_parent(self, api_client, documents_connector):
+        parent = DocumentFolder.objects.create(name='Raíz')
+        _, token = documents_connector
+        response = _call(api_client, token, 'create_folder', {'name': 'Sub', 'parent_id': parent.id})
+        assert response.data['result']['isError'] is False
+        created = DocumentFolder.objects.get(name='Sub')
+        assert created.parent_id == parent.id
+
+    def test_create_folder_requires_name(self, api_client, documents_connector):
+        _, token = documents_connector
+        response = _call(api_client, token, 'create_folder', {'name': '   '})
+        assert response.data['result']['isError'] is True
+
+
+@pytest.mark.django_db
+class TestDocumentsMcpCrud:
+    def test_create_document_parses_markdown_and_builds_json(self, api_client, documents_connector, markdown_doc_type):
+        _, token = documents_connector
+        response = _call(api_client, token, 'create_document', {
+            'title': 'Guía',
+            'markdown': '# Título\n\nUn párrafo.',
+        })
+        assert response.data['result']['isError'] is False
+        doc = Document.objects.get(title='Guía')
+        assert doc.document_type.code == 'markdown'
+        assert doc.content_json['blocks']  # parser produced blocks
+        assert doc.content_json['meta']['title'] == 'Guía'
+
+    def test_read_document_returns_markdown(self, api_client, documents_connector, markdown_doc_type):
+        doc = _make_doc(markdown_doc_type, title='Leer', content_markdown='# X\n\nY.')
+        _, token = documents_connector
+        response = _call(api_client, token, 'read_document', {'document_id': doc.id})
+        text = response.data['result']['content'][0]['text']
+        assert '# X' in text
+
+    def test_update_document_reparses_markdown(self, api_client, documents_connector, markdown_doc_type):
+        doc = _make_doc(markdown_doc_type, title='Old')
+        _, token = documents_connector
+        response = _call(api_client, token, 'update_document', {
+            'document_id': doc.id,
+            'title': 'New',
+            'markdown': '# Nuevo\n\nContenido.',
+        })
+        assert response.data['result']['isError'] is False
+        doc.refresh_from_db()
+        assert doc.title == 'New'
+        assert doc.content_json['meta']['title'] == 'New'
+        assert doc.content_markdown.startswith('# Nuevo')
+
+    def test_update_document_requires_at_least_one_field(self, api_client, documents_connector, markdown_doc_type):
+        doc = _make_doc(markdown_doc_type)
+        _, token = documents_connector
+        response = _call(api_client, token, 'update_document', {'document_id': doc.id})
+        assert response.data['result']['isError'] is True
+
+    def test_delete_unpublished_document(self, api_client, documents_connector, markdown_doc_type):
+        doc = _make_doc(markdown_doc_type, status='draft')
+        _, token = documents_connector
+        response = _call(api_client, token, 'delete_document', {'document_id': doc.id})
+        assert response.data['result']['isError'] is False
+        assert not Document.objects.filter(pk=doc.id).exists()
+
+    def test_cannot_delete_published_document(self, api_client, documents_connector, markdown_doc_type):
+        doc = _make_doc(markdown_doc_type, status='published')
+        _, token = documents_connector
+        response = _call(api_client, token, 'delete_document', {'document_id': doc.id})
+        assert response.data['result']['isError'] is True
+        assert Document.objects.filter(pk=doc.id).exists()
+
+
+@pytest.mark.django_db
+class TestDocumentsMcpMarkdownGuardrail:
+    def test_list_documents_excludes_collection_accounts(self, api_client, documents_connector, markdown_doc_type, collection_account_type):
+        _make_doc(markdown_doc_type, title='Markdown doc')
+        _make_doc(collection_account_type, title='Cuenta de cobro')
+        _, token = documents_connector
+        response = _call(api_client, token, 'list_documents', {})
+        text = response.data['result']['content'][0]['text']
+        assert 'Markdown doc' in text
+        assert 'Cuenta de cobro' not in text
+
+    def test_cannot_read_collection_account(self, api_client, documents_connector, collection_account_type):
+        doc = _make_doc(collection_account_type, title='Cuenta')
+        _, token = documents_connector
+        response = _call(api_client, token, 'read_document', {'document_id': doc.id})
+        assert response.data['result']['isError'] is True
+
+    def test_cannot_delete_collection_account(self, api_client, documents_connector, collection_account_type):
+        doc = _make_doc(collection_account_type, title='Cuenta', status='draft')
+        _, token = documents_connector
+        response = _call(api_client, token, 'delete_document', {'document_id': doc.id})
+        assert response.data['result']['isError'] is True
+        assert Document.objects.filter(pk=doc.id).exists()
+
+
+@pytest.fixture
+def superuser_client(api_client, django_user_model):
+    user = django_user_model.objects.create_user(
+        username='root_docs_test', password='x', is_staff=True, is_superuser=True,
+    )
+    api_client.force_authenticate(user=user)
+    return api_client
+
+
+@pytest.mark.django_db
+class TestDocumentsConnectorPanel:
+    def test_panel_lists_documents_connector_with_tools(self, superuser_client, documents_connector):
+        response = superuser_client.get('/api/mcp-connectors/')
+        docs = next(c for c in response.data if c['slug'] == 'documents')
+        tool_names = [t['name'] for t in docs['tools']]
+        assert 'create_document' in tool_names
+        assert 'list_folders' in tool_names

--- a/backend/content/views/mcp_blog.py
+++ b/backend/content/views/mcp_blog.py
@@ -22,6 +22,7 @@ from rest_framework.response import Response
 from rest_framework.throttling import AnonRateThrottle
 
 from content.mcp.protocol import handle_message
+from content.mcp.document_tools import DOCUMENT_TOOLS
 from content.mcp.tools import BLOG_TOOLS
 from content.models import McpConnector, McpRequestLog
 from content.permissions import IsSuperUser
@@ -33,6 +34,7 @@ LAST_USED_TOUCH_SECONDS = 60
 # One entry per exposed MCP connector: slug -> tool registry.
 TOOLS_BY_SLUG = {
     'blog': BLOG_TOOLS,
+    'documents': DOCUMENT_TOOLS,
 }
 
 

--- a/frontend/components/base/BaseToggle.vue
+++ b/frontend/components/base/BaseToggle.vue
@@ -10,8 +10,10 @@ const props = defineProps({
   // Color shown when modelValue is true. Defaults to brand primary.
   // Use a semantic class like 'bg-warning-strong' to convey state instead of action.
   onClass: { type: String, default: 'bg-primary' },
-  // Color shown when modelValue is false. Defaults to muted raised surface.
-  offClass: { type: String, default: 'bg-surface-raised border border-border-default' },
+  // Color shown when modelValue is false. A brand-tinted border keeps the
+  // (near-white) off track visible on light surfaces — a plain neutral border
+  // is out-competed by the base `border-transparent`, so force it important.
+  offClass: { type: String, default: 'bg-surface-raised !border-primary' },
 })
 
 const emit = defineEmits(['update:modelValue'])


### PR DESCRIPTION
Reuses the Blog Publisher MCP infrastructure end to end — the token-authed Streamable HTTP endpoint, JSON-RPC protocol, Origin validation, activity trail and the generic /panel/mcps UI — by adding a second connector slug.

New "documents" connector exposes the panel's document manager to Claude: list/create folders, and list/read/create/update/delete markdown documents. Documents are authored in Markdown and the panel renders them to PDF downstream, so the tools produce Markdown and rebuild content_json via the same markdown parser the panel uses.

Guardrails:
- Only MARKDOWN-type documents are visible or mutable; commercial collection accounts (cuentas de cobro) in the same table stay out of reach.
- Published documents cannot be deleted (unpublish first or use the panel).
- Folders can be listed and created, not renamed or deleted.

Changes:
- content/mcp/document_tools.py: DOCUMENT_TOOLS registry + handlers.
- content/views/mcp_blog.py: register 'documents' in TOOLS_BY_SLUG.
- migration 0131: seed the 'documents' connector (inactive by default).

Test plan:
- pytest content/tests/views/test_mcp_documents.py (15 passed)
- pytest content/tests/views/test_mcp_blog.py (35 passed, no regression)
- python manage.py check clean