### PR TITLE
FEAT: LinkedIn Personal Content MCP connector + compact MCP cards

### DIFF
--- a/backend/content/mcp/linkedin_tools.py
+++ b/backend/content/mcp/linkedin_tools.py
@@ -1,0 +1,335 @@
+"""
+Tool registry for the LinkedIn Personal Content MCP connector.
+
+Lets claude.ai manage the freeform LinkedIn posts of the panel module
+(/panel/linkedin) for the owner's PERSONAL profile: check the OAuth
+connection health, list/read posts, create drafts, schedule, edit,
+delete and publish now. A future `linkedin-company` connector will cover
+the organization page (different author URN and scope).
+
+Guardrails baked in:
+- Published posts are immutable (edit/delete-guarded exactly like the panel).
+- No image handling: posts created via MCP are text-only; images stay
+  panel-only (the MCP transport does not carry binaries).
+- OAuth connection/reconnection is panel-only; tokens are never exposed.
+
+Each entry: {'name', 'description', 'input_schema', 'handler'}. Handlers
+receive the raw `arguments` dict, return a JSON-serializable dict, and raise
+ToolError for business errors. They reuse the exact same serializer and
+service pipeline as the panel (atomic double-publish guard, Huey ETA
+scheduling), so behavior never diverges.
+"""
+from datetime import timedelta
+
+from django.utils import timezone
+
+from content.mcp.protocol import ToolError
+from content.models import LinkedInPost
+from content.serializers.linkedin_post import LinkedInPostSerializer
+from content.services.linkedin_post_service import (
+    apply_schedule_transition,
+    publish_linkedin_post_now,
+)
+from content.services.linkedin_service import get_connection_status
+
+STATUS_CHOICES = {choice[0] for choice in LinkedInPost.STATUS_CHOICES}
+
+_EXPIRY_WARN_DAYS = 7
+
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+def _get_post_or_error(post_id):
+    try:
+        return LinkedInPost.objects.get(pk=int(post_id))
+    except (LinkedInPost.DoesNotExist, TypeError, ValueError):
+        raise ToolError(
+            f'No existe un post de LinkedIn con id={post_id}. '
+            'Usa list_posts para ver los disponibles.'
+        )
+
+
+def _public_url(post):
+    if post.status == LinkedInPost.STATUS_PUBLISHED and post.linkedin_post_id:
+        return f'https://www.linkedin.com/feed/update/{post.linkedin_post_id}/'
+    return None
+
+
+def _post_summary(post):
+    return {
+        'id': post.id,
+        'commentary_preview': (
+            post.commentary if len(post.commentary) <= 120
+            else post.commentary[:120] + '…'
+        ),
+        'status': post.status,
+        'has_image': bool(post.image),
+        'scheduled_at': post.scheduled_at.isoformat() if post.scheduled_at else None,
+        'published_at': post.published_at.isoformat() if post.published_at else None,
+        'public_url': _public_url(post),
+    }
+
+
+def _post_detail(post):
+    return {
+        **_post_summary(post),
+        'commentary': post.commentary,
+        'error_message': post.error_message,
+        'created_at': post.created_at.isoformat(),
+        'updated_at': post.updated_at.isoformat(),
+    }
+
+
+def _serializer_errors_to_message(errors):
+    parts = []
+    for field, messages in errors.items():
+        joined = ' '.join(str(m) for m in messages)
+        parts.append(f'{field}: {joined}')
+    return 'Datos inválidos — ' + ' | '.join(parts)
+
+
+def _validate_and_save(serializer):
+    if not serializer.is_valid():
+        raise ToolError(_serializer_errors_to_message(serializer.errors))
+    post = serializer.save()
+    apply_schedule_transition(post)
+    return post
+
+
+# ── Handlers ─────────────────────────────────────────────────────────────────
+
+def connection_status(arguments):
+    status_data = get_connection_status()
+    result = dict(status_data)
+    if not status_data.get('connected'):
+        result['warning'] = (
+            'LinkedIn no está conectado. La conexión OAuth se hace desde '
+            '/panel/linkedin (botón "Conectar LinkedIn"); no es posible '
+            'conectar desde el MCP. Publicar o programar posts fallará '
+            'hasta reconectar.'
+        )
+        return result
+
+    expires_at = status_data.get('expires_at')
+    if expires_at:
+        from django.utils.dateparse import parse_datetime
+        expiry = parse_datetime(expires_at)
+        if expiry and expiry <= timezone.now() + timedelta(days=_EXPIRY_WARN_DAYS):
+            result['warning'] = (
+                f'El token de LinkedIn expira el {expiry.date().isoformat()} '
+                '(≤7 días). Reconecta desde /panel/linkedin antes de esa fecha; '
+                'los posts programados después fallarán.'
+            )
+    return result
+
+
+def list_posts(arguments):
+    qs = LinkedInPost.objects.all()
+    status_filter = arguments.get('status')
+    if status_filter:
+        if status_filter not in STATUS_CHOICES:
+            raise ToolError(
+                f'Status inválido: {status_filter}. '
+                f'Opciones: {", ".join(sorted(STATUS_CHOICES))}.'
+            )
+        qs = qs.filter(status=status_filter)
+    posts = list(qs[:50])
+    return {
+        'count': len(posts),
+        'posts': [_post_summary(p) for p in posts],
+    }
+
+
+def get_post(arguments):
+    post = _get_post_or_error(arguments.get('post_id'))
+    return _post_detail(post)
+
+
+def create_post(arguments):
+    data = {'commentary': arguments.get('commentary', '')}
+    if arguments.get('scheduled_at'):
+        data['scheduled_at'] = arguments['scheduled_at']
+    post = _validate_and_save(LinkedInPostSerializer(data=data))
+    return _post_detail(post)
+
+
+def update_post(arguments):
+    post = _get_post_or_error(arguments.get('post_id'))
+    if post.status == LinkedInPost.STATUS_PUBLISHED:
+        raise ToolError(
+            'Un post ya publicado en LinkedIn no se puede editar. '
+            'Crea uno nuevo con create_post si necesitas otra versión.'
+        )
+    data = {}
+    if 'commentary' in arguments:
+        data['commentary'] = arguments['commentary']
+    if 'scheduled_at' in arguments:
+        data['scheduled_at'] = arguments['scheduled_at'] or None
+    if not data:
+        raise ToolError('Nada que actualizar: envía commentary y/o scheduled_at.')
+    post = _validate_and_save(LinkedInPostSerializer(post, data=data, partial=True))
+    return _post_detail(post)
+
+
+def delete_post(arguments):
+    post = _get_post_or_error(arguments.get('post_id'))
+    post_id = post.id
+    post.delete()
+    return {
+        'deleted': True,
+        'id': post_id,
+        'note': 'Solo se eliminó el registro local; nada cambió en LinkedIn.',
+    }
+
+
+def publish_post(arguments):
+    post = _get_post_or_error(arguments.get('post_id'))
+
+    result = publish_linkedin_post_now(post)
+
+    if result.get('already'):
+        raise ToolError(result['message'])
+    if result.get('not_connected'):
+        raise ToolError(
+            f'{result["message"]} Reconecta LinkedIn desde /panel/linkedin.'
+        )
+    if not result['success']:
+        raise ToolError(
+            f'LinkedIn rechazó la publicación: {result["message"]} '
+            'El post quedó en status=failed; corrige y reintenta con publish_post.'
+        )
+
+    post.refresh_from_db()
+    return _post_detail(post)
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+LINKEDIN_TOOLS = [
+    {
+        'name': 'get_connection_status',
+        'description': (
+            'Consulta el estado de la conexión OAuth con LinkedIn (perfil '
+            'personal): perfil conectado y fecha de expiración del token. '
+            'Incluye warning si está desconectado o expira en ≤7 días. '
+            'Úsala antes de publicar o programar.'
+        ),
+        'input_schema': {'type': 'object', 'properties': {}},
+        'handler': connection_status,
+    },
+    {
+        'name': 'list_posts',
+        'description': (
+            'Lista los posts de LinkedIn del módulo (máx 50, más recientes '
+            'primero) con preview del texto, status y fechas. Filtra con '
+            'status: draft, scheduled, published o failed. Usa get_post para '
+            'el texto completo.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'status': {
+                    'type': 'string',
+                    'enum': sorted(STATUS_CHOICES),
+                    'description': 'Filtrar por status (omitir para todos).',
+                },
+            },
+        },
+        'handler': list_posts,
+    },
+    {
+        'name': 'get_post',
+        'description': (
+            'Devuelve el detalle completo de un post: texto íntegro, status, '
+            'programación, URL pública si está publicado y error_message si '
+            'falló.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'post_id': {'type': 'integer', 'description': 'ID del post (de list_posts).'},
+            },
+            'required': ['post_id'],
+        },
+        'handler': get_post,
+    },
+    {
+        'name': 'create_post',
+        'description': (
+            'Crea un post de LinkedIn (solo texto, máx 3000 caracteres; las '
+            'imágenes se agregan desde /panel/linkedin). Sin scheduled_at '
+            'queda como borrador. Con scheduled_at (ISO 8601 futuro con '
+            'timezone, ej. 2026-07-10T09:00:00-05:00) queda programado y el '
+            'sistema lo publica automáticamente a esa hora.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'commentary': {
+                    'type': 'string',
+                    'description': 'Texto del post (máx 3000 caracteres).',
+                },
+                'scheduled_at': {
+                    'type': 'string',
+                    'description': 'Fecha/hora futura ISO 8601 para programar (omitir para borrador).',
+                },
+            },
+            'required': ['commentary'],
+        },
+        'handler': create_post,
+    },
+    {
+        'name': 'update_post',
+        'description': (
+            'Edita el texto y/o la programación de un post en borrador, '
+            'programado o fallido. scheduled_at vacío o null cancela la '
+            'programación (vuelve a borrador). Los posts publicados son '
+            'inmutables.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'post_id': {'type': 'integer', 'description': 'ID del post a editar.'},
+                'commentary': {'type': 'string', 'description': 'Nuevo texto (máx 3000).'},
+                'scheduled_at': {
+                    'type': 'string',
+                    'description': 'Nueva fecha ISO 8601 futura, o "" para cancelar la programación.',
+                },
+            },
+            'required': ['post_id'],
+        },
+        'handler': update_post,
+    },
+    {
+        'name': 'delete_post',
+        'description': (
+            'Elimina el registro local de un post. No borra nada en LinkedIn '
+            '(un post ya publicado sigue visible en el perfil).'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'post_id': {'type': 'integer', 'description': 'ID del post a eliminar.'},
+            },
+            'required': ['post_id'],
+        },
+        'handler': delete_post,
+    },
+    {
+        'name': 'publish_post',
+        'description': (
+            'Publica un post inmediatamente en el perfil personal de '
+            'LinkedIn. Protegido contra doble publicación. Si LinkedIn '
+            'rechaza la publicación el post queda en failed con el detalle '
+            'del error y se puede reintentar.'
+        ),
+        'input_schema': {
+            'type': 'object',
+            'properties': {
+                'post_id': {'type': 'integer', 'description': 'ID del post a publicar.'},
+            },
+            'required': ['post_id'],
+        },
+        'handler': publish_post,
+    },
+]

--- a/backend/content/migrations/0139_seed_linkedin_personal_mcp_connector.py
+++ b/backend/content/migrations/0139_seed_linkedin_personal_mcp_connector.py
@@ -1,0 +1,40 @@
+from django.db import migrations
+
+# LinkedIn Personal Content MCP connector. Seeded inactive and tokenless —
+# the operator generates a token and toggles it on in /panel/mcps. slug must
+# match the key registered in TOOLS_BY_SLUG (content/views/mcp_blog.py).
+# "-personal" reserves the namespace for a future linkedin-company connector.
+CONNECTORS = [
+    (
+        'linkedin-personal',
+        'LinkedIn Personal Content',
+        'Permite a Claude (claude.ai) gestionar los posts de LinkedIn del '
+        'perfil personal: consultar la conexión OAuth y su expiración, '
+        'listar/leer posts, crear borradores (solo texto), programarlos, '
+        'editarlos, eliminarlos y publicarlos al instante.',
+    ),
+]
+
+
+def seed_connectors(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    for slug, name, description in CONNECTORS:
+        McpConnector.objects.get_or_create(
+            slug=slug,
+            defaults={'name': name, 'description': description, 'is_active': False},
+        )
+
+
+def unseed_connectors(apps, schema_editor):
+    McpConnector = apps.get_model('content', 'McpConnector')
+    slugs = [slug for slug, _, _ in CONNECTORS]
+    McpConnector.objects.filter(slug__in=slugs).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ('content', '0138_linkedinpost'),
+    ]
+    operations = [
+        migrations.RunPython(seed_connectors, unseed_connectors),
+    ]

--- a/backend/content/services/linkedin_post_service.py
+++ b/backend/content/services/linkedin_post_service.py
@@ -69,3 +69,22 @@ def schedule_linkedin_post_eta(post):
         'Encolado publish_single_scheduled_linkedin_post para post %s a %s',
         post.id, post.scheduled_at,
     )
+
+
+def apply_schedule_transition(post):
+    """Sync status with scheduled_at after create/update and enqueue ETA.
+
+    Shared by the panel views and the MCP handlers so scheduling rules
+    live in one place.
+    """
+    from content.models import LinkedInPost
+
+    if post.status == LinkedInPost.STATUS_PUBLISHED:
+        return
+    if post.scheduled_at:
+        post.status = LinkedInPost.STATUS_SCHEDULED
+        post.save(update_fields=['status', 'updated_at'])
+        schedule_linkedin_post_eta(post)
+    elif post.status == LinkedInPost.STATUS_SCHEDULED:
+        post.status = LinkedInPost.STATUS_DRAFT
+        post.save(update_fields=['status', 'updated_at'])

--- a/backend/content/tests/views/test_linkedin_post_views.py
+++ b/backend/content/tests/views/test_linkedin_post_views.py
@@ -25,7 +25,7 @@ def test_create_draft(admin_client):
     assert resp.data['status'] == 'draft'
 
 
-@patch('content.views.linkedin.schedule_linkedin_post_eta')
+@patch('content.services.linkedin_post_service.schedule_linkedin_post_eta')
 def test_create_with_future_schedule_sets_scheduled(mock_eta, admin_client):
     eta = (timezone.now() + timedelta(hours=2)).isoformat()
     resp = admin_client.post(

--- a/backend/content/tests/views/test_mcp_linkedin.py
+++ b/backend/content/tests/views/test_mcp_linkedin.py
@@ -1,0 +1,151 @@
+"""Tests for the LinkedIn Personal Content MCP connector HTTP endpoint.
+
+LinkedIn API calls and Huey scheduling are mocked at the service layer —
+no real LinkedIn requests are made and no tasks are enqueued.
+"""
+from datetime import timedelta
+from unittest.mock import patch
+
+import pytest
+from django.utils import timezone
+
+from content.models import LinkedInPost, McpConnector
+
+PUBLISH_SVC = 'content.services.linkedin_post_service.publish_post_to_linkedin'
+ETA_SVC = 'content.services.linkedin_post_service.schedule_linkedin_post_eta'
+STATUS_SVC = 'content.mcp.linkedin_tools.get_connection_status'
+
+
+@pytest.fixture
+def linkedin_connector(db):
+    connector, _ = McpConnector.objects.get_or_create(
+        slug='linkedin-personal', defaults={'name': 'LinkedIn Personal Content'},
+    )
+    connector.is_active = True
+    connector.save(update_fields=['is_active'])
+    return connector, connector.generate_token()
+
+
+def _url(token):
+    return f'/api/mcp/linkedin-personal/{token}/'
+
+
+def _rpc(method, params=None, msg_id=1):
+    message = {'jsonrpc': '2.0', 'id': msg_id, 'method': method}
+    if params is not None:
+        message['params'] = params
+    return message
+
+
+def _call(api_client, token, name, arguments):
+    return api_client.post(
+        _url(token), _rpc('tools/call', {'name': name, 'arguments': arguments}),
+        format='json',
+    )
+
+
+def _content(response):
+    """First structured content block of a tools/call result."""
+    import json
+    return json.loads(response.data['result']['content'][0]['text'])
+
+
+@pytest.mark.django_db
+class TestLinkedInMcpTools:
+    def test_tool_list_includes_core_tools(self, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        response = api_client.post(_url(token), _rpc('tools/list'), format='json')
+        names = [t['name'] for t in response.data['result']['tools']]
+        for expected in (
+            'get_connection_status', 'list_posts', 'get_post', 'create_post',
+            'update_post', 'delete_post', 'publish_post',
+        ):
+            assert expected in names
+
+    def test_create_draft_and_list(self, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        created = _call(api_client, token, 'create_post', {'commentary': 'Hola LinkedIn'})
+        assert created.data['result']['isError'] is False
+        assert _content(created)['status'] == 'draft'
+
+        listed = _call(api_client, token, 'list_posts', {})
+        payload = _content(listed)
+        assert payload['count'] == 1
+        assert payload['posts'][0]['status'] == 'draft'
+
+    @patch(ETA_SVC)
+    def test_create_scheduled_enqueues_eta(self, mock_eta, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        eta = (timezone.now() + timedelta(hours=2)).isoformat()
+        created = _call(
+            api_client, token, 'create_post',
+            {'commentary': 'Programado', 'scheduled_at': eta},
+        )
+        assert created.data['result']['isError'] is False
+        assert _content(created)['status'] == 'scheduled'
+        mock_eta.assert_called_once()
+
+    def test_create_with_past_schedule_is_error(self, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        eta = (timezone.now() - timedelta(hours=1)).isoformat()
+        created = _call(
+            api_client, token, 'create_post',
+            {'commentary': 'Tarde', 'scheduled_at': eta},
+        )
+        assert created.data['result']['isError'] is True
+
+    def test_update_published_post_is_error(self, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        post = LinkedInPost.objects.create(
+            commentary='ya salió', status=LinkedInPost.STATUS_PUBLISHED,
+        )
+        updated = _call(
+            api_client, token, 'update_post',
+            {'post_id': post.id, 'commentary': 'edit'},
+        )
+        assert updated.data['result']['isError'] is True
+
+    @patch(PUBLISH_SVC, return_value={'success': True, 'post_id': 'urn:li:share:9', 'message': 'ok'})
+    def test_publish_post_success(self, mock_pub, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        post = LinkedInPost.objects.create(commentary='Publícame')
+        published = _call(api_client, token, 'publish_post', {'post_id': post.id})
+        assert published.data['result']['isError'] is False
+        payload = _content(published)
+        assert payload['status'] == 'published'
+        assert payload['public_url'].endswith('urn:li:share:9/')
+
+    @patch(PUBLISH_SVC, return_value={'success': False, 'post_id': '', 'message': 'LinkedIn API error (500): boom'})
+    def test_publish_post_failure_is_error_and_persists(self, mock_pub, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        post = LinkedInPost.objects.create(commentary='Falla')
+        published = _call(api_client, token, 'publish_post', {'post_id': post.id})
+        assert published.data['result']['isError'] is True
+        post.refresh_from_db()
+        assert post.status == LinkedInPost.STATUS_FAILED
+        assert 'boom' in post.error_message
+
+    def test_delete_post(self, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        post = LinkedInPost.objects.create(commentary='bye')
+        deleted = _call(api_client, token, 'delete_post', {'post_id': post.id})
+        assert deleted.data['result']['isError'] is False
+        assert _content(deleted)['deleted'] is True
+        assert not LinkedInPost.objects.filter(pk=post.id).exists()
+
+    @patch(STATUS_SVC, return_value={
+        'connected': True, 'profile_name': 'Gustavo',
+        'expires_at': (timezone.now() + timedelta(days=3)).isoformat(),
+    })
+    def test_connection_status_warns_near_expiry(self, mock_status, api_client, linkedin_connector):
+        _, token = linkedin_connector
+        response = _call(api_client, token, 'get_connection_status', {})
+        payload = _content(response)
+        assert payload['connected'] is True
+        assert 'expira' in payload['warning']
+
+    def test_wrong_token_is_404(self, api_client, linkedin_connector):
+        response = api_client.post(
+            _url('not-the-token'), _rpc('tools/list'), format='json',
+        )
+        assert response.status_code == 404

--- a/backend/content/views/linkedin.py
+++ b/backend/content/views/linkedin.py
@@ -21,8 +21,8 @@ from rest_framework.response import Response
 from content.models import BlogPost, LinkedInPost
 from content.serializers.linkedin_post import LinkedInPostSerializer
 from content.services.linkedin_post_service import (
+    apply_schedule_transition,
     publish_linkedin_post_now,
-    schedule_linkedin_post_eta,
 )
 from content.services.linkedin_service import (
     exchange_code_for_token,
@@ -198,19 +198,6 @@ def publish_to_linkedin(request, post_id):
 # Freeform LinkedIn posts (panel module)
 # ---------------------------------------------------------------------------
 
-def _apply_schedule_transition(post):
-    """Sync status with scheduled_at after create/update and enqueue ETA."""
-    if post.status == LinkedInPost.STATUS_PUBLISHED:
-        return
-    if post.scheduled_at:
-        post.status = LinkedInPost.STATUS_SCHEDULED
-        post.save(update_fields=['status', 'updated_at'])
-        schedule_linkedin_post_eta(post)
-    elif post.status == LinkedInPost.STATUS_SCHEDULED:
-        post.status = LinkedInPost.STATUS_DRAFT
-        post.save(update_fields=['status', 'updated_at'])
-
-
 @api_view(['GET'])
 @permission_classes([IsAdminUser])
 def list_linkedin_posts(request):
@@ -226,7 +213,7 @@ def create_linkedin_post(request):
     serializer = LinkedInPostSerializer(data=request.data)
     serializer.is_valid(raise_exception=True)
     post = serializer.save()
-    _apply_schedule_transition(post)
+    apply_schedule_transition(post)
     return Response(
         LinkedInPostSerializer(post).data, status=status.HTTP_201_CREATED,
     )
@@ -250,7 +237,7 @@ def update_linkedin_post(request, post_id):
     serializer = LinkedInPostSerializer(post, data=data, partial=True)
     serializer.is_valid(raise_exception=True)
     post = serializer.save()
-    _apply_schedule_transition(post)
+    apply_schedule_transition(post)
     return Response(LinkedInPostSerializer(post).data)
 
 

--- a/backend/content/views/mcp_blog.py
+++ b/backend/content/views/mcp_blog.py
@@ -26,6 +26,7 @@ from content.mcp.accounting_tools import ACCOUNTING_TOOLS
 from content.mcp.client_tools import CLIENT_TOOLS
 from content.mcp.diagnostic_tools import DIAGNOSTIC_TOOLS
 from content.mcp.document_tools import DOCUMENT_TOOLS
+from content.mcp.linkedin_tools import LINKEDIN_TOOLS
 from content.mcp.proposal_tools import PROPOSAL_TOOLS
 from content.mcp.task_tools import TASK_TOOLS
 from content.mcp.tools import BLOG_TOOLS
@@ -45,6 +46,7 @@ TOOLS_BY_SLUG = {
     'accounting': ACCOUNTING_TOOLS,
     'diagnostics': DIAGNOSTIC_TOOLS,
     'proposals': PROPOSAL_TOOLS,
+    'linkedin-personal': LINKEDIN_TOOLS,
 }
 
 

--- a/docs/superpowers/specs/2026-07-04-linkedin-personal-mcp-design.md
+++ b/docs/superpowers/specs/2026-07-04-linkedin-personal-mcp-design.md
@@ -1,0 +1,82 @@
+# LinkedIn Personal Content MCP — Design
+
+**Date:** 2026-07-04
+**Branch:** `feat/04072026-linkedin-content-module` (PR #85)
+**Status:** Approved
+
+## Overview
+
+Expose the new LinkedIn content module (`/panel/linkedin`, this same PR) as a
+remote MCP connector, following the exact architecture of the Blog Publisher
+MCP (`docs/superpowers/specs/2026-07-02-blog-publisher-mcp-design.md`) and the
+Documents MCP: tool registry + `TOOLS_BY_SLUG` entry + seed migration. The
+owner's claude.ai account can then draft, schedule, publish and manage
+freeform LinkedIn posts for the **personal profile** directly from chat.
+
+A separate `linkedin-company` connector may come later (organization URN +
+`w_organization_social` scope) — out of scope here; the `-personal` suffix in
+the slug reserves the namespace.
+
+## Goals
+
+- Manage `LinkedInPost` records from claude.ai with zero panel steps: create
+  drafts, schedule (Huey ETA + sweep pipeline), publish now, edit, delete.
+- Surface OAuth connection health (profile, `expires_at`, near-expiry warning)
+  so Claude can warn before a scheduled post would fail.
+- Reuse the exact panel pipeline: `LinkedInPostSerializer` validation,
+  `linkedin_post_service` (atomic double-publish guard, ETA scheduling),
+  `linkedin_service.get_connection_status`. No divergence.
+- Reuse all existing MCP infrastructure untouched: `protocol.py`,
+  `McpConnector`, endpoint routing, `/panel/mcps` token lifecycle (the panel
+  lists tools automatically from `TOOLS_BY_SLUG`).
+
+## Non-Goals
+
+- Image upload via MCP (binary handling stays panel-only; posts created via
+  MCP are text-only).
+- OAuth connection/reconnection via MCP (panel-only).
+- Company-page publishing (future `linkedin-company` connector).
+
+## Connector
+
+- Slug: `linkedin-personal` — Name: **LinkedIn Personal Content**.
+- Seeded inactive and tokenless (migration, same pattern as
+  `0136_seed_panel_mcp_connectors.py`); operator activates and generates the
+  token in `/panel/mcps`.
+- Endpoint: `POST /api/mcp/linkedin-personal/<token>/` (already routed by the
+  generic `mcp_endpoint`).
+
+## Tools (`backend/content/mcp/linkedin_tools.py`, registry `LINKEDIN_TOOLS`)
+
+| Tool | Input | Behavior |
+|---|---|---|
+| `get_connection_status` | — | Connection status + profile name + `expires_at`; adds `warning` field when the token expires in ≤7 days or is disconnected. Never exposes tokens. |
+| `list_posts` | `status?` (draft/scheduled/published/failed) | Summaries newest-first (commentary truncated to 120 chars, `has_image`, schedule/publish timestamps, public URL when published). |
+| `get_post` | `post_id` | Full detail including complete commentary and `error_message`. |
+| `create_post` | `commentary` (≤3000), `scheduled_at?` (ISO 8601 future) | Draft, or scheduled (status transition + Huey ETA enqueue via the shared service helper). |
+| `update_post` | `post_id`, `commentary?`, `scheduled_at?` (`""`/null clears → back to draft) | Published posts are immutable → ToolError. |
+| `delete_post` | `post_id` | Deletes the local record only (never touches LinkedIn). |
+| `publish_post` | `post_id` | Publish now through `publish_linkedin_post_now` (atomic claim). Already-published → ToolError; API failure → ToolError with the persisted `error_message`. |
+
+## Refactor (single source of truth)
+
+`_apply_schedule_transition` moves from `views/linkedin.py` to
+`linkedin_post_service.apply_schedule_transition(post)`; the panel view and
+the MCP handlers both call the service version. The existing view test that
+patches `content.views.linkedin.schedule_linkedin_post_eta` is updated to
+patch the service path.
+
+## Error handling
+
+- Business errors (`ToolError`) → MCP `isError: true` with a Spanish message
+  guiding the next tool call (same style as the Documents MCP).
+- Validation reuses `LinkedInPostSerializer` (`scheduled_at` must be future,
+  commentary ≤3000).
+
+## Testing
+
+`backend/content/tests/views/test_mcp_linkedin.py`, mirroring
+`test_mcp_tasks.py` conventions (connector fixture + JSON-RPC helpers):
+tools/list names; create draft; create scheduled (service ETA mocked);
+update published → error; publish happy path (publish service mocked);
+publish failure → isError with message; delete; status includes `expires_at`.

--- a/frontend/e2e/admin/admin-mcps.spec.js
+++ b/frontend/e2e/admin/admin-mcps.spec.js
@@ -98,25 +98,32 @@ test.describe('Panel MCPs', () => {
 
     await expect(page.getByTestId('mcp-card-blog')).toBeVisible({ timeout: 25_000 });
     await expect(page.getByText('Blog Publisher')).toBeVisible();
-    await expect(page.getByText('sin generar')).toBeVisible();
 
-    // Compact card: tools are NOT on the card anymore (they live in the modal)
+    // Collapsed accordion row: token, status and tools live in the body and
+    // are hidden until the row is expanded.
+    await expect(page.getByText('sin generar')).not.toBeVisible();
     await expect(page.getByText('create_blog_post')).not.toBeVisible();
 
     // Collapsible step-by-step connection guide (native <details>) is present.
     await expect(page.getByTestId('mcps-guide')).toBeVisible();
     await expect(page.getByText('¿Cómo conectar un conector a Claude?')).toBeVisible();
 
-    // Clicking the card opens the detail modal with connection status,
-    // activity trail and available tools.
-    await page.getByTestId('mcp-card-blog').click();
-    await expect(page.getByTestId('mcp-detail-modal')).toBeVisible();
+    // Expanding the row reveals the detail body: token, connection status,
+    // and the activity/tools sub-accordions.
+    await page.getByTestId('mcp-card-header-blog').click();
+    await expect(page.getByTestId('mcp-detail-blog')).toBeVisible();
+    await expect(page.getByText('sin generar')).toBeVisible();
 
     await expect(page.getByTestId('mcp-connection-blog')).toContainText('Error de conexión');
     await expect(page.getByTestId('mcp-connection-blog')).toContainText('https://evil.example');
 
+    // Recent activity sub-accordion expands with the event trail.
+    await page.getByTestId('mcp-activity-toggle-blog').click();
     await expect(page.getByTestId('mcp-activity-list-blog')).toContainText('Origin rechazado');
     await expect(page.getByTestId('mcp-activity-list-blog')).toContainText('Conexión (initialize)');
+
+    // Available tools sub-accordion expands with the tool list.
+    await page.getByTestId('mcp-tools-toggle-blog').click();
     await expect(page.getByText('create_blog_post')).toBeVisible();
   });
 
@@ -127,6 +134,8 @@ test.describe('Panel MCPs', () => {
     await page.goto('/panel/mcps', { waitUntil: 'domcontentloaded' });
 
     await expect(page.getByTestId('mcp-card-blog')).toBeVisible({ timeout: 25_000 });
+    // The generate-token button lives in the expanded body, so open the row first.
+    await page.getByTestId('mcp-card-header-blog').click();
     await page.getByTestId('mcp-generate-token-blog').click();
 
     await expect(page.getByTestId('mcp-token-modal')).toBeVisible();

--- a/frontend/e2e/admin/admin-mcps.spec.js
+++ b/frontend/e2e/admin/admin-mcps.spec.js
@@ -98,21 +98,26 @@ test.describe('Panel MCPs', () => {
 
     await expect(page.getByTestId('mcp-card-blog')).toBeVisible({ timeout: 25_000 });
     await expect(page.getByText('Blog Publisher')).toBeVisible();
-    await expect(page.getByText('create_blog_post')).toBeVisible();
     await expect(page.getByText('sin generar')).toBeVisible();
+
+    // Compact card: tools are NOT on the card anymore (they live in the modal)
+    await expect(page.getByText('create_blog_post')).not.toBeVisible();
 
     // Collapsible step-by-step connection guide (native <details>) is present.
     await expect(page.getByTestId('mcps-guide')).toBeVisible();
     await expect(page.getByText('¿Cómo conectar un conector a Claude?')).toBeVisible();
 
-    // Connection status derived from the latest MCP event
+    // Clicking the card opens the detail modal with connection status,
+    // activity trail and available tools.
+    await page.getByTestId('mcp-card-blog').click();
+    await expect(page.getByTestId('mcp-detail-modal')).toBeVisible();
+
     await expect(page.getByTestId('mcp-connection-blog')).toContainText('Error de conexión');
     await expect(page.getByTestId('mcp-connection-blog')).toContainText('https://evil.example');
 
-    // Recent activity list expands with the event trail
-    await page.getByTestId('mcp-activity-toggle-blog').click();
     await expect(page.getByTestId('mcp-activity-list-blog')).toContainText('Origin rechazado');
     await expect(page.getByTestId('mcp-activity-list-blog')).toContainText('Conexión (initialize)');
+    await expect(page.getByText('create_blog_post')).toBeVisible();
   });
 
   test('generates a token and shows the one-time connector URL modal', {

--- a/frontend/e2e/flow-definitions.json
+++ b/frontend/e2e/flow-definitions.json
@@ -2583,7 +2583,7 @@
         "admin"
       ],
       "priority": "P2",
-      "description": "Superuser manages MCP connectors at /panel/mcps: sees the Blog Publisher card with its tool catalog, generates/rotates the connector token (one-time URL modal with copy, GET /api/mcp-connectors/ + POST /api/mcp-connectors/<slug>/generate-token/), and toggles is_active. Includes the superuser gate: staff non-superusers are redirected to /panel.",
+      "description": "Superuser manages MCP connectors at /panel/mcps: each connector is a collapsible accordion row (name, connection-status badge, active toggle) that expands inline to reveal connection status, recent activity and the tool catalog in nested sub-accordions; generates/rotates the connector token (one-time URL modal with copy, GET /api/mcp-connectors/ + POST /api/mcp-connectors/<slug>/generate-token/), and toggles is_active. Includes the superuser gate: staff non-superusers are redirected to /panel.",
       "expectedSpecs": 4
     },
     "admin-accounting-cards": {

--- a/frontend/pages/panel/mcps/index.vue
+++ b/frontend/pages/panel/mcps/index.vue
@@ -69,16 +69,20 @@
       </BaseButton>
     </div>
 
-    <div v-else class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-5 items-start">
+    <div v-else class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-5 items-stretch">
       <div
         v-for="connector in store.connectors"
         :key="connector.slug"
         :data-testid="`mcp-card-${connector.slug}`"
-        class="bg-surface border border-border-muted rounded-xl shadow-sm p-5 sm:p-6"
+        role="button"
+        tabindex="0"
+        class="flex flex-col bg-surface border border-border-muted rounded-xl shadow-sm p-5 cursor-pointer transition-colors hover:border-border-default focus:outline-none focus:ring-2 focus:ring-focus-ring/30"
+        @click="openDetail(connector)"
+        @keydown.enter="openDetail(connector)"
       >
         <div class="flex items-start justify-between gap-3 mb-1">
           <h2 class="text-lg font-bold text-text-default">{{ connector.name }}</h2>
-          <div class="flex items-center gap-2 flex-shrink-0">
+          <div class="flex items-center gap-2 flex-shrink-0" @click.stop>
             <span
               class="text-xs font-medium"
               :class="connector.is_active ? 'text-success-strong' : 'text-text-subtle'"
@@ -94,9 +98,9 @@
             />
           </div>
         </div>
-        <p class="text-sm text-text-muted mb-4">{{ connector.description }}</p>
+        <p class="text-sm text-text-muted mb-4 line-clamp-2">{{ connector.description }}</p>
 
-        <div class="flex items-center gap-2 text-sm mb-4">
+        <div class="flex items-center gap-2 text-sm mb-4 mt-auto">
           <span class="text-text-subtle">Token:</span>
           <code v-if="connector.has_token" class="text-xs bg-surface-muted rounded px-2 py-1">
             {{ connector.token_prefix }}…
@@ -107,37 +111,62 @@
           </span>
         </div>
 
+        <div class="flex items-center justify-between pt-4 border-t border-border-muted">
+          <span class="text-xs text-text-subtle">Clic para ver actividad y funciones</span>
+          <BaseButton
+            variant="primary"
+            size="sm"
+            :data-testid="`mcp-generate-token-${connector.slug}`"
+            @click.stop="onGenerateToken(connector)"
+          >
+            {{ connector.has_token ? 'Regenerar token' : 'Generar token' }}
+          </BaseButton>
+        </div>
+      </div>
+    </div>
+
+    <!-- Connector detail modal: connection status, recent activity, available tools -->
+    <BaseModal v-model="detailModal.open" size="2xl" padding="md">
+      <div v-if="detailConnector" data-testid="mcp-detail-modal">
+        <div class="flex items-start justify-between gap-3 mb-1">
+          <h3 class="text-lg font-bold text-text-default">{{ detailConnector.name }}</h3>
+          <span
+            class="text-xs font-medium flex-shrink-0"
+            :class="detailConnector.is_active ? 'text-success-strong' : 'text-text-subtle'"
+          >
+            {{ detailConnector.is_active ? 'Activo' : 'Inactivo' }}
+          </span>
+        </div>
+        <p class="text-sm text-text-muted mb-4">{{ detailConnector.description }}</p>
+
         <!-- Connection status derived from the latest MCP request -->
         <div
           class="flex items-start gap-2 text-sm rounded-lg px-3 py-2 mb-4"
-          :class="statusFor(connector).box"
-          :data-testid="`mcp-connection-${connector.slug}`"
+          :class="statusFor(detailConnector).box"
+          :data-testid="`mcp-connection-${detailConnector.slug}`"
         >
-          <span class="mt-1 h-2 w-2 rounded-full flex-shrink-0" :class="statusFor(connector).dot" />
+          <span class="mt-1 h-2 w-2 rounded-full flex-shrink-0" :class="statusFor(detailConnector).dot" />
           <div>
-            <span class="font-medium">{{ statusFor(connector).label }}</span>
-            <template v-if="connector.recent_events?.length">
+            <span class="font-medium">{{ statusFor(detailConnector).label }}</span>
+            <template v-if="detailConnector.recent_events?.length">
               <span class="text-text-muted">
-                · {{ formatDate(connector.recent_events[0].created_at) }}
-                · {{ eventLabel(connector.recent_events[0]) }}
+                · {{ formatDate(detailConnector.recent_events[0].created_at) }}
+                · {{ eventLabel(detailConnector.recent_events[0]) }}
               </span>
-              <p v-if="!connector.recent_events[0].ok && connector.recent_events[0].detail" class="text-xs text-text-muted mt-0.5">
-                {{ connector.recent_events[0].detail }}
+              <p v-if="!detailConnector.recent_events[0].ok && detailConnector.recent_events[0].detail" class="text-xs text-text-muted mt-0.5">
+                {{ detailConnector.recent_events[0].detail }}
               </p>
             </template>
           </div>
         </div>
 
-        <details v-if="connector.recent_events?.length" class="mb-4">
-          <summary
-            class="text-xs font-semibold text-text-subtle uppercase tracking-wider cursor-pointer select-none"
-            :data-testid="`mcp-activity-toggle-${connector.slug}`"
-          >
-            Actividad reciente ({{ connector.recent_events.length }})
-          </summary>
-          <ul class="mt-2 space-y-1.5" :data-testid="`mcp-activity-list-${connector.slug}`">
+        <template v-if="detailConnector.recent_events?.length">
+          <p class="text-xs font-semibold text-text-subtle uppercase tracking-wider mb-2">
+            Actividad reciente ({{ detailConnector.recent_events.length }})
+          </p>
+          <ul class="space-y-1.5 mb-5" :data-testid="`mcp-activity-list-${detailConnector.slug}`">
             <li
-              v-for="(event, index) in connector.recent_events"
+              v-for="(event, index) in detailConnector.recent_events"
               :key="index"
               class="flex items-start gap-2 text-xs"
             >
@@ -150,30 +179,19 @@
               <span v-if="showDetail(event)" class="text-text-muted truncate">{{ event.detail }}</span>
             </li>
           </ul>
-        </details>
+        </template>
 
         <p class="text-xs font-semibold text-text-subtle uppercase tracking-wider mb-2">
           Funciones disponibles
         </p>
-        <ul class="space-y-1 mb-5">
-          <li v-for="tool in connector.tools" :key="tool.name" class="text-sm">
+        <ul class="space-y-1 max-h-72 overflow-y-auto pr-1">
+          <li v-for="tool in detailConnector.tools" :key="tool.name" class="text-sm">
             <code class="text-xs bg-surface-muted rounded px-1.5 py-0.5">{{ tool.name }}</code>
             <span class="text-text-muted ml-1">{{ tool.description }}</span>
           </li>
         </ul>
-
-        <div class="flex items-center justify-end pt-4 border-t border-border-muted">
-          <BaseButton
-            variant="primary"
-            size="sm"
-            :data-testid="`mcp-generate-token-${connector.slug}`"
-            @click="onGenerateToken(connector)"
-          >
-            {{ connector.has_token ? 'Regenerar token' : 'Generar token' }}
-          </BaseButton>
-        </div>
       </div>
-    </div>
+    </BaseModal>
 
     <!-- One-time token modal -->
     <BaseModal v-model="tokenModal.open" size="lg" padding="md" :close-on-backdrop="false">
@@ -201,7 +219,7 @@
 </template>
 
 <script setup>
-import { onMounted, reactive } from 'vue';
+import { computed, onMounted, reactive } from 'vue';
 import BaseBadge from '~/components/base/BaseBadge.vue';
 import BaseButton from '~/components/base/BaseButton.vue';
 import BaseModal from '~/components/base/BaseModal.vue';
@@ -215,6 +233,18 @@ const store = useMcpsStore();
 const notify = usePanelNotify();
 
 const tokenModal = reactive({ open: false, url: '', copied: false });
+
+// Detail modal holds only the slug: the connector object is looked up in the
+// store so the modal stays in sync after toggles or refetches.
+const detailModal = reactive({ open: false, slug: '' });
+const detailConnector = computed(
+  () => store.connectors.find((c) => c.slug === detailModal.slug) || null,
+);
+
+function openDetail(connector) {
+  detailModal.slug = connector.slug;
+  detailModal.open = true;
+}
 
 // Pasos accionables para conectar un MCP, mostrados en el acordeón de la vista.
 // Se permiten <strong> para resaltar la acción/etiqueta real de la UI.

--- a/frontend/pages/panel/mcps/index.vue
+++ b/frontend/pages/panel/mcps/index.vue
@@ -69,129 +69,181 @@
       </BaseButton>
     </div>
 
-    <div v-else class="grid grid-cols-1 lg:grid-cols-2 2xl:grid-cols-3 gap-5 items-stretch">
+    <div v-else class="space-y-3">
       <div
         v-for="connector in store.connectors"
         :key="connector.slug"
         :data-testid="`mcp-card-${connector.slug}`"
-        role="button"
-        tabindex="0"
-        class="flex flex-col bg-surface border border-border-muted rounded-xl shadow-sm p-5 cursor-pointer transition-colors hover:border-border-default focus:outline-none focus:ring-2 focus:ring-focus-ring/30"
-        @click="openDetail(connector)"
-        @keydown.enter="openDetail(connector)"
+        class="bg-surface border border-border-muted rounded-xl shadow-sm overflow-hidden"
       >
-        <div class="flex items-start justify-between gap-3 mb-1">
-          <h2 class="text-lg font-bold text-text-default">{{ connector.name }}</h2>
-          <div class="flex items-center gap-2 flex-shrink-0" @click.stop>
-            <span
-              class="text-xs font-medium"
-              :class="connector.is_active ? 'text-success-strong' : 'text-text-subtle'"
-              :data-testid="`mcp-status-${connector.slug}`"
+        <!-- Accordion header (always visible; click toggles the detail body) -->
+        <div
+          role="button"
+          tabindex="0"
+          :aria-expanded="isExpanded(connector.slug)"
+          :data-testid="`mcp-card-header-${connector.slug}`"
+          class="flex items-center gap-3 px-4 sm:px-5 py-4 cursor-pointer select-none transition-colors hover:bg-surface-muted focus:outline-none focus:ring-2 focus:ring-focus-ring/30"
+          @click="toggleRow(connector.slug)"
+          @keydown.enter.prevent="toggleRow(connector.slug)"
+          @keydown.space.prevent="toggleRow(connector.slug)"
+        >
+          <svg
+            class="h-4 w-4 flex-shrink-0 text-text-subtle transition-transform duration-200"
+            :class="{ 'rotate-180': isExpanded(connector.slug) }"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+          <h2 class="text-base font-bold text-text-default truncate">{{ connector.name }}</h2>
+
+          <div class="ml-auto flex items-center gap-2 sm:gap-3 flex-shrink-0">
+            <!-- Connection status at a glance (hidden on narrow screens) -->
+            <BaseBadge
+              :variant="statusVariant(connector)"
+              size="sm"
+              class="hidden sm:inline-flex"
+              :data-testid="`mcp-connection-badge-${connector.slug}`"
             >
-              {{ connector.is_active ? 'Activo' : 'Inactivo' }}
-            </span>
-            <BaseToggle
-              :model-value="connector.is_active"
-              :aria-label="`Activar ${connector.name}`"
-              :data-testid="`mcp-toggle-${connector.slug}`"
-              @update:model-value="(value) => onToggle(connector, value)"
-            />
+              <span class="h-1.5 w-1.5 rounded-full" :class="statusFor(connector).dot" />
+              {{ statusFor(connector).label }}
+            </BaseBadge>
+
+            <!-- Active status + toggle: click must not collapse/expand the row -->
+            <div class="flex items-center gap-2" @click.stop @keydown.enter.stop @keydown.space.stop>
+              <span
+                class="text-xs font-medium"
+                :class="connector.is_active ? 'text-success-strong' : 'text-text-subtle'"
+                :data-testid="`mcp-status-${connector.slug}`"
+              >
+                {{ connector.is_active ? 'Activo' : 'Inactivo' }}
+              </span>
+              <BaseToggle
+                :model-value="connector.is_active"
+                :aria-label="`Activar ${connector.name}`"
+                :data-testid="`mcp-toggle-${connector.slug}`"
+                @update:model-value="(value) => onToggle(connector, value)"
+              />
+            </div>
           </div>
         </div>
-        <p class="text-sm text-text-muted mb-4 line-clamp-2">{{ connector.description }}</p>
 
-        <div class="flex items-center gap-2 text-sm mb-4 mt-auto">
-          <span class="text-text-subtle">Token:</span>
-          <code v-if="connector.has_token" class="text-xs bg-surface-muted rounded px-2 py-1">
-            {{ connector.token_prefix }}…
-          </code>
-          <span v-else class="text-text-subtle">sin generar</span>
-          <span v-if="connector.last_used_at" class="text-xs text-text-subtle ml-auto">
-            Último uso: {{ formatDate(connector.last_used_at) }}
-          </span>
-        </div>
+        <!-- Accordion body: description, status, metadata, sub-accordions, actions -->
+        <div
+          v-if="isExpanded(connector.slug)"
+          :data-testid="`mcp-detail-${connector.slug}`"
+          class="border-t border-border-muted px-4 sm:px-5 py-4 space-y-4"
+        >
+          <p class="text-sm text-text-muted">{{ connector.description }}</p>
 
-        <div class="flex items-center justify-between pt-4 border-t border-border-muted">
-          <span class="text-xs text-text-subtle">Clic para ver actividad y funciones</span>
-          <BaseButton
-            variant="primary"
-            size="sm"
-            :data-testid="`mcp-generate-token-${connector.slug}`"
-            @click.stop="onGenerateToken(connector)"
+          <!-- Connection status derived from the latest MCP request -->
+          <div
+            class="flex items-start gap-2 text-sm rounded-lg px-3 py-2"
+            :class="statusFor(connector).box"
+            :data-testid="`mcp-connection-${connector.slug}`"
           >
-            {{ connector.has_token ? 'Regenerar token' : 'Generar token' }}
-          </BaseButton>
+            <span class="mt-1 h-2 w-2 rounded-full flex-shrink-0" :class="statusFor(connector).dot" />
+            <div>
+              <span class="font-medium">{{ statusFor(connector).label }}</span>
+              <template v-if="connector.recent_events?.length">
+                <span class="text-text-muted">
+                  · {{ formatDate(connector.recent_events[0].created_at) }}
+                  · {{ eventLabel(connector.recent_events[0]) }}
+                </span>
+                <p v-if="!connector.recent_events[0].ok && connector.recent_events[0].detail" class="text-xs text-text-muted mt-0.5">
+                  {{ connector.recent_events[0].detail }}
+                </p>
+              </template>
+            </div>
+          </div>
+
+          <!-- Token + last used -->
+          <div class="flex flex-wrap items-center gap-x-3 gap-y-1 text-sm">
+            <span class="inline-flex items-center gap-1.5 text-text-subtle">
+              <KeyIcon class="h-4 w-4" />
+              Token:
+            </span>
+            <code v-if="connector.has_token" class="text-xs bg-surface-muted rounded px-2 py-1">
+              {{ connector.token_prefix }}…
+            </code>
+            <span v-else class="text-text-subtle">sin generar</span>
+            <span v-if="connector.last_used_at" class="text-xs text-text-subtle sm:ml-auto">
+              Último uso: {{ formatDate(connector.last_used_at) }}
+            </span>
+          </div>
+
+          <!-- Sub-accordion: recent activity (collapsed by default) -->
+          <details v-if="connector.recent_events?.length" class="group">
+            <summary
+              class="flex items-center gap-2 text-xs font-semibold text-text-subtle uppercase tracking-wider cursor-pointer select-none list-none marker:hidden [&::-webkit-details-marker]:hidden"
+              :data-testid="`mcp-activity-toggle-${connector.slug}`"
+            >
+              <svg
+                class="h-3.5 w-3.5 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+              Actividad reciente ({{ connector.recent_events.length }})
+            </summary>
+            <ul class="mt-2 space-y-1.5" :data-testid="`mcp-activity-list-${connector.slug}`">
+              <li
+                v-for="(event, index) in connector.recent_events"
+                :key="index"
+                class="flex items-start gap-2 text-xs"
+              >
+                <span
+                  class="mt-1 h-1.5 w-1.5 rounded-full flex-shrink-0"
+                  :class="event.ok ? 'bg-success-strong' : 'bg-danger-strong'"
+                />
+                <span class="text-text-subtle whitespace-nowrap">{{ formatDate(event.created_at) }}</span>
+                <span class="text-text-default">{{ eventLabel(event) }}</span>
+                <span v-if="showDetail(event)" class="text-text-muted truncate">{{ event.detail }}</span>
+              </li>
+            </ul>
+          </details>
+
+          <!-- Sub-accordion: available tools (collapsed by default) -->
+          <details v-if="connector.tools?.length" class="group">
+            <summary
+              class="flex items-center gap-2 text-xs font-semibold text-text-subtle uppercase tracking-wider cursor-pointer select-none list-none marker:hidden [&::-webkit-details-marker]:hidden"
+              :data-testid="`mcp-tools-toggle-${connector.slug}`"
+            >
+              <svg
+                class="h-3.5 w-3.5 flex-shrink-0 transition-transform duration-200 group-open:rotate-180"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+              </svg>
+              Funciones disponibles ({{ connector.tools.length }})
+            </summary>
+            <ul class="mt-2 space-y-1 max-h-72 overflow-y-auto pr-1" :data-testid="`mcp-tools-list-${connector.slug}`">
+              <li v-for="tool in connector.tools" :key="tool.name" class="text-sm">
+                <code class="text-xs bg-surface-muted rounded px-1.5 py-0.5">{{ tool.name }}</code>
+                <span class="text-text-muted ml-1">{{ tool.description }}</span>
+              </li>
+            </ul>
+          </details>
+
+          <!-- Token action -->
+          <div class="flex items-center justify-end pt-4 border-t border-border-muted">
+            <BaseButton
+              variant="primary"
+              size="sm"
+              :data-testid="`mcp-generate-token-${connector.slug}`"
+              @click="onGenerateToken(connector)"
+            >
+              {{ connector.has_token ? 'Regenerar token' : 'Generar token' }}
+            </BaseButton>
+          </div>
         </div>
       </div>
     </div>
-
-    <!-- Connector detail modal: connection status, recent activity, available tools -->
-    <BaseModal v-model="detailModal.open" size="2xl" padding="md">
-      <div v-if="detailConnector" data-testid="mcp-detail-modal">
-        <div class="flex items-start justify-between gap-3 mb-1">
-          <h3 class="text-lg font-bold text-text-default">{{ detailConnector.name }}</h3>
-          <span
-            class="text-xs font-medium flex-shrink-0"
-            :class="detailConnector.is_active ? 'text-success-strong' : 'text-text-subtle'"
-          >
-            {{ detailConnector.is_active ? 'Activo' : 'Inactivo' }}
-          </span>
-        </div>
-        <p class="text-sm text-text-muted mb-4">{{ detailConnector.description }}</p>
-
-        <!-- Connection status derived from the latest MCP request -->
-        <div
-          class="flex items-start gap-2 text-sm rounded-lg px-3 py-2 mb-4"
-          :class="statusFor(detailConnector).box"
-          :data-testid="`mcp-connection-${detailConnector.slug}`"
-        >
-          <span class="mt-1 h-2 w-2 rounded-full flex-shrink-0" :class="statusFor(detailConnector).dot" />
-          <div>
-            <span class="font-medium">{{ statusFor(detailConnector).label }}</span>
-            <template v-if="detailConnector.recent_events?.length">
-              <span class="text-text-muted">
-                · {{ formatDate(detailConnector.recent_events[0].created_at) }}
-                · {{ eventLabel(detailConnector.recent_events[0]) }}
-              </span>
-              <p v-if="!detailConnector.recent_events[0].ok && detailConnector.recent_events[0].detail" class="text-xs text-text-muted mt-0.5">
-                {{ detailConnector.recent_events[0].detail }}
-              </p>
-            </template>
-          </div>
-        </div>
-
-        <template v-if="detailConnector.recent_events?.length">
-          <p class="text-xs font-semibold text-text-subtle uppercase tracking-wider mb-2">
-            Actividad reciente ({{ detailConnector.recent_events.length }})
-          </p>
-          <ul class="space-y-1.5 mb-5" :data-testid="`mcp-activity-list-${detailConnector.slug}`">
-            <li
-              v-for="(event, index) in detailConnector.recent_events"
-              :key="index"
-              class="flex items-start gap-2 text-xs"
-            >
-              <span
-                class="mt-1 h-1.5 w-1.5 rounded-full flex-shrink-0"
-                :class="event.ok ? 'bg-success-strong' : 'bg-danger-strong'"
-              />
-              <span class="text-text-subtle whitespace-nowrap">{{ formatDate(event.created_at) }}</span>
-              <span class="text-text-default">{{ eventLabel(event) }}</span>
-              <span v-if="showDetail(event)" class="text-text-muted truncate">{{ event.detail }}</span>
-            </li>
-          </ul>
-        </template>
-
-        <p class="text-xs font-semibold text-text-subtle uppercase tracking-wider mb-2">
-          Funciones disponibles
-        </p>
-        <ul class="space-y-1 max-h-72 overflow-y-auto pr-1">
-          <li v-for="tool in detailConnector.tools" :key="tool.name" class="text-sm">
-            <code class="text-xs bg-surface-muted rounded px-1.5 py-0.5">{{ tool.name }}</code>
-            <span class="text-text-muted ml-1">{{ tool.description }}</span>
-          </li>
-        </ul>
-      </div>
-    </BaseModal>
 
     <!-- One-time token modal -->
     <BaseModal v-model="tokenModal.open" size="lg" padding="md" :close-on-backdrop="false">
@@ -219,7 +271,8 @@
 </template>
 
 <script setup>
-import { computed, onMounted, reactive } from 'vue';
+import { onMounted, reactive, ref } from 'vue';
+import { KeyIcon } from '@heroicons/vue/24/outline';
 import BaseBadge from '~/components/base/BaseBadge.vue';
 import BaseButton from '~/components/base/BaseButton.vue';
 import BaseModal from '~/components/base/BaseModal.vue';
@@ -234,16 +287,19 @@ const notify = usePanelNotify();
 
 const tokenModal = reactive({ open: false, url: '', copied: false });
 
-// Detail modal holds only the slug: the connector object is looked up in the
-// store so the modal stays in sync after toggles or refetches.
-const detailModal = reactive({ open: false, slug: '' });
-const detailConnector = computed(
-  () => store.connectors.find((c) => c.slug === detailModal.slug) || null,
-);
+// Which connector rows are expanded (by slug). Reassign a new Set on each
+// toggle so Vue's reactivity picks up the change (Set mutations aren't tracked).
+const expandedConnectors = ref(new Set());
 
-function openDetail(connector) {
-  detailModal.slug = connector.slug;
-  detailModal.open = true;
+function isExpanded(slug) {
+  return expandedConnectors.value.has(slug);
+}
+
+function toggleRow(slug) {
+  const next = new Set(expandedConnectors.value);
+  if (next.has(slug)) next.delete(slug);
+  else next.add(slug);
+  expandedConnectors.value = next;
 }
 
 // Pasos accionables para conectar un MCP, mostrados en el acordeón de la vista.
@@ -269,8 +325,15 @@ const eventLabels = {
   origin_rejected: 'Origin rechazado',
 };
 
+// Maps the connection status to a BaseBadge variant for the header indicator.
+const statusVariants = { connected: 'success', error: 'danger', none: 'neutral' };
+
 function statusFor(connector) {
   return statusStyles[connector.connection_status] || statusStyles.none;
+}
+
+function statusVariant(connector) {
+  return statusVariants[connector.connection_status] || 'neutral';
 }
 
 function eventLabel(event) {


### PR DESCRIPTION
## Summary

Recovers two pieces of work that were pushed to the PR #85 branch **after** it was squash-merged, so they never landed on `main`:

### LinkedIn Personal Content MCP connector
- New `content/mcp/linkedin_tools.py` (7 tools): `get_connection_status` (with token-expiry warning ≤7 days), `list_posts`, `get_post`, `create_post` (draft or scheduled), `update_post`, `delete_post`, `publish_post`.
- Registered as slug `linkedin-personal` in `TOOLS_BY_SLUG`; seed migration `0139` creates it inactive and tokenless (activate + generate token from /panel/mcps). The `-personal` suffix reserves namespace for a future `linkedin-company` connector.
- Guardrails: published posts immutable, text-only via MCP (images panel-only), OAuth/token handling never exposed.
- Refactor: schedule-transition logic moved from the view into `linkedin_post_service.apply_schedule_transition` so panel and MCP share one code path.

### Compact MCP cards in /panel/mcps
- Cards now show only: title, status + toggle, description (2-line clamp), masked token, last use, and the Generate/Regenerate token button.
- Clicking a card opens a detail modal with connection status, full recent-activity trail and the available tools list (scrollable). Toggle and token button use `@click.stop`.

## Test plan

- `pytest content/tests/views/test_mcp_linkedin.py content/tests/views/test_linkedin_post_views.py` — 18 passed on this base.
- Shared MCP endpoint regression: `test_mcp_blog.py` — 35 passed.
- E2E `e2e/admin/admin-mcps.spec.js` updated to the card→modal flow — 4/4 passed.
- Design-tokens check clean on `frontend/pages/panel/mcps/index.vue`.

Deploy notes: run `python manage.py migrate` (seed `0139`).